### PR TITLE
Lost Better Check in Product Admin display merge

### DIFF
--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -584,6 +584,9 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 			foreach ( $tabs as $key => $tab ) {
 				if ( 'general' != $key && 'advanced' != $key && 'shipping' != $key ) {
 					$tabs[ $key ]['class'][] = 'hide_if_wgm_gift_card';
+					if (isset($tabs[ $key ]['class']) and is_array($tabs[ $key ]['class'])) {
+						$tabs[ $key ]['class'][] = 'hide_if_wgm_gift_card';
+					}
 				}
 			}
 			$tabs = apply_filters( 'mwb_wgm_product_data_tabs', $tabs );


### PR DESCRIPTION
Was already merged in https://github.com/wpswings/woo-gift-cards-lite/commit/919fecabfea4a35a01e4585ff0eb63c566930bfe
But may be lost in later Updates...

If other Addons change Tabs in the Woo Product page we got an error with gift cards Addon.
This may be related to an unproper Tab configuration in the other Addon.
The additional Check in the mwb_wgm_woocommerce_product_data_tabs method fixes that cross beahviour.