### PR TITLE
feature/WPS-6570-dashboard-design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 pull_requests
 script
 docs
+.codex
+woocommerce-plugin-performance-optimizer

--- a/admin/css/woocommerce_gift_cards_lite-admin.css
+++ b/admin/css/woocommerce_gift_cards_lite-admin.css
@@ -328,10 +328,10 @@
      margin-bottom: 0;
  }
  
- .wps_wgm_table_wrapper.wps_wgm_overview-wrapper p {
-     font-size: 16px;
-     padding: 0 10px 20px;
- }
+.wps_wgm_overview_content > p {
+    font-size: 16px;
+    padding: 0 10px 20px;
+}
  
  .wps_wgm_video_wrapper iframe {
      width: 100%;
@@ -636,18 +636,21 @@
  input.remove_giftcard_redeem_details,
  .wps_gw_open_redeem_link,
  .update_giftcard_redeem_details {
-     background-color: #2196f3;
-     color: #ffffff;
-     padding: 17px 30px;
-     display: inline-block;
+     align-items: center;
+     background: #111;
+     border: none;
+     border-radius: 999px;
+     color: #fff;
+     cursor: pointer;
+     display: inline-flex;
+     font-size: 13px;
+     font-weight: 700;
+     justify-content: center;
+     letter-spacing: 0.03em;
+     min-height: 46px;
+     padding: 0 22px;
      text-decoration: none;
      margin-top: 15px;
-     border-radius: 4px;
-     text-transform: capitalize;
-     font-size: 16px;
-     cursor: pointer;
-     line-height: 1.4;
-     border: 1px solid #2196f3;
  }
  
  .wps_redeem_details .remove_giftcard_redeem_details,
@@ -674,12 +677,8 @@
  }
  
  .wps_redeem_div_wrapper .generate_link {
-     box-shadow: 0 4px 11px rgba(145, 92, 182, .55), 0 -2px 0 rgba(0, 0, 0, 0.2) inset;
-     font-size: 15px;
-     font-weight: 600;
      left: 0;
      margin: 0 auto;
-     padding: 12px;
  }
  
  .wps-giftware-reddem-image.text-center {
@@ -694,9 +693,7 @@
  .wps_redeem_div_wrapper .generate_link:hover,
  .wps_redeem_div_wrapper .generate_link:focus {
      outline: 0;
-     background-color: #ffffff;
-     color: #333333;
-     box-shadow: 0 7px 21px rgba(145, 92, 182, .55), 0 -2px 0 rgba(0, 0, 0, 0.2) inset;
+     color: #fff;
  }
  
  a.wps_gw_open_redeem_link {
@@ -711,10 +708,8 @@
  input.remove_giftcard_redeem_details:focus,
  .update_giftcard_redeem_details:hover,
  .update_giftcard_redeem_details:focus {
-     background-color: #ffffff;
-     color: #2196f3;
+     color: #fff;
      outline: 0;
-     box-shadow: none;
  }
  
  .wps_gw_open_redeem_link:hover,
@@ -778,8 +773,13 @@
  
  .wps_redeem_registraion_div .wps_gw_general_setting input[type="email"],
  .wps_redeem_registraion_div .wps_gw_general_setting input[type="text"] {
+     min-width: 300px;
      padding: 10px !important;
-     width: 90% !important;
+     width: 100% !important;
+ }
+ .wps_redeem_registraion_div .wps_gw_general_setting label {
+     display: block;
+     width: 100%;
  }
  
  .wps_redeem_details {
@@ -809,7 +809,7 @@
 }
 
 .wps_redeem_registraion_div .wps_gw_general_setting td.forminp .input-text {
-    max-width: 350px;
+    max-width: 100%;
  }
  
  #wps_gw_setting_wrapper table.wps_redeem_details thead th {
@@ -1195,13 +1195,44 @@
      cursor: pointer;
  }
  
- .wps_wgm_mail_setting_tab {
+.wps_wgm_mail_setting_tab {
+     align-items: center;
      background-color: #2196f3;
      color: #ffffff;
+     display: flex;
+     justify-content: space-between;
      margin: 9px 0 0;
      padding: 10px;
      font-size: 16px;
      cursor: pointer;
+ }
+
+ .wps_wgm_mail_setting_tab_label {
+     display: inline-block;
+ }
+
+ .wps_wgm_mail_setting_toggle {
+     display: inline-flex;
+     align-items: center;
+     justify-content: center;
+     flex: 0 0 auto;
+     width: 24px;
+     height: 24px;
+ }
+
+ .wps_wgm_mail_setting_toggle::before {
+     border-bottom: 2px solid currentColor;
+     border-right: 2px solid currentColor;
+     content: "";
+     display: block;
+     height: 8px;
+     transform: rotate(45deg);
+     transition: transform 0.2s ease;
+     width: 8px;
+ }
+
+ .wps_wgm_mail_setting_tab.is-open .wps_wgm_mail_setting_toggle::before {
+     transform: rotate(-135deg);
  }
  
  #wps_wgm_mail_setting_wrapper {
@@ -1357,15 +1388,19 @@
  }
  
  a.wps_wgm--cta {
-     background: #2196f3;
-     border-radius: 50px;
-     color: #ffffff;
-     display: inline-block;
-     font-size: 18px;
-     font-weight: 600;
-     padding: 8px 50px;
-     text-transform: uppercase;
+     align-items: center;
+     background: #111;
+     border-radius: 999px;
+     color: #fff;
+     display: inline-flex;
+     font-size: 13px;
+     font-weight: 700;
+     justify-content: center;
+     letter-spacing: 0.03em;
+     min-height: 46px;
+     padding: 0 28px;
      text-decoration: none;
+     text-transform: uppercase;
  }
  
  /*=====================================
@@ -1594,8 +1629,208 @@
      margin-bottom: 15px;
      margin-top: 20px;
  }
- .wps_wgm_video_wrapper {
-    max-width: calc(100% - 30px);
+.wps_wgm_video_wrapper {
+   max-width: calc(100% - 30px);
+}
+
+.wps-wgm-overview {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.wps-wgm-overview__hero {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0 auto;
+    max-width: 760px;
+    text-align: center;
+}
+
+.wps-wgm-overview__icon {
+    align-items: center;
+    background: radial-gradient(circle at top, #fff4d6, #ffcc74);
+    border-radius: 22px;
+    color: #1f2057;
+    display: inline-flex;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 20px;
+    height: 84px;
+    justify-content: center;
+    letter-spacing: 0.08em;
+    width: 84px;
+}
+
+.wps-wgm-overview__eyebrow {
+    color: #ff9f1a;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.wps-wgm-overview__hero h2 {
+    color: #1f2057;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 46px;
+    line-height: 1.08;
+    margin: 0;
+}
+
+.wps-wgm-overview__hero p {
+    color: #6e6a8d;
+    font-size: 17px;
+    line-height: 1.75;
+    margin: 0;
+    padding: 0;
+}
+
+.wps-wgm-overview__heading-row {
+    align-items: center;
+    color: #1f2057;
+    display: flex;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 20px;
+    gap: 16px;
+    justify-content: center;
+}
+
+.wps-wgm-overview__heading-row::before,
+.wps-wgm-overview__heading-row::after {
+    background: linear-gradient(90deg, transparent, #e6ddf7, transparent);
+    content: "";
+    flex: 1 1 auto;
+    height: 1px;
+    max-width: 180px;
+}
+
+.wps-wgm-overview__grid {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.wps-wgm-overview-card {
+    background: #ffffff;
+    border: 1px solid #e6ddf7;
+    border-radius: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 22px;
+}
+
+.wps-wgm-overview-card__media {
+    align-items: center;
+    background: #f7f3ff;
+    border-radius: 16px;
+    display: flex;
+    height: 74px;
+    justify-content: center;
+    width: 74px;
+}
+
+.wps-wgm-overview-card__media img {
+    max-height: 46px;
+    max-width: 46px;
+    object-fit: contain;
+}
+
+.wps-wgm-overview-card h3 {
+    color: #1f2057;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 22px;
+    line-height: 1.2;
+    margin: 0;
+}
+
+.wps-wgm-overview-card p {
+    color: #6e6a8d;
+    font-size: 14px;
+    line-height: 1.7;
+    margin: 0;
+    padding: 0;
+}
+
+.wps-wgm-overview__cta {
+    align-items: center;
+    background: linear-gradient(90deg, #f9f5ff 0%, #ffffff 100%);
+    border: 1px solid #e6ddf7;
+    border-radius: 18px;
+    display: flex;
+    gap: 18px;
+    justify-content: space-between;
+    padding: 22px 24px;
+}
+
+.wps-wgm-overview__cta strong {
+    color: #1f2057;
+    display: block;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 20px;
+    margin-bottom: 6px;
+}
+
+.wps-wgm-overview__cta p {
+    color: #6e6a8d;
+    margin: 0;
+    padding: 0;
+}
+
+.wps-wgm-overview__cta-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.wps-wgm-overview__button {
+    align-items: center;
+    border-radius: 999px;
+    display: inline-flex;
+    font-family: "NunitoSans-ExtraBold", sans-serif;
+    font-size: 14px;
+    justify-content: center;
+    min-height: 46px;
+    padding: 0 22px;
+    text-decoration: none;
+    transition: transform 0.2s ease;
+}
+
+.wps-wgm-overview__button:hover,
+.wps-wgm-overview__button:focus {
+    transform: translateY(-1px);
+}
+
+.wps-wgm-overview__button--secondary {
+    background: #111111;
+    color: #ffffff;
+}
+
+.wps-wgm-overview__button--secondary:hover,
+.wps-wgm-overview__button--secondary:focus {
+    color: #ffffff;
+}
+
+@media (max-width: 768px) {
+    .wps-wgm-overview__cta {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .wps-wgm-overview__cta-actions {
+        width: 100%;
+    }
+
+    .wps-wgm-overview__hero h2 {
+        font-size: 32px;
+    }
+}
+
+@media (max-width: 640px) {
+    .wps-wgm-overview__grid {
+        grid-template-columns: 1fr;
+    }
 }
 .wps_wgm__content img {
     max-width: 160px;
@@ -1867,4 +2102,2602 @@ th label[for=wps_wgm_new_gift_card_page_layout], th label[for=wps_wgm_select_lib
 }
 .wps_ml-35 {
     margin-left: 35px;
+}
+
+#wps_wgm_setting_wrapper {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 20px 20px 0 0;
+}
+
+#wps_wgm_setting_wrapper .notice {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_shell {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner {
+    align-items: center;
+    background: linear-gradient(135deg, #f7edcf 0%, #f4e3b6 100%);
+    border: 1px solid #ead7a1;
+    border-radius: 16px;
+    box-shadow: 0 14px 40px rgba(29, 35, 39, 0.08);
+    display: grid;
+    gap: 18px;
+    grid-template-columns: 120px minmax(0, 1fr) auto;
+    padding: 22px 26px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_badge {
+    align-items: center;
+    align-self: start;
+    background: #ff9f1a;
+    border-radius: 999px;
+    color: #fff;
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 700;
+    justify-content: center;
+    letter-spacing: 0.08em;
+    min-height: 36px;
+    padding: 0 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_copy h1 {
+    color: #2f214e;
+    font-size: 34px;
+    line-height: 1.1;
+    margin: 0 0 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_copy p {
+    color: #60566f;
+    font-size: 15px;
+    line-height: 1.6;
+    margin: 0;
+    max-width: 760px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action {
+    align-items: center;
+    background: #111;
+    border-radius: 999px;
+    color: #fff;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 600;
+    justify-content: center;
+    min-height: 42px;
+    padding: 0 18px;
+    text-decoration: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action:hover,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action:focus {
+    color: #fff;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action_secondary {
+    background: #fff;
+    border: 1px solid #d6d2df;
+    color: #2f214e;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action_secondary:hover,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action_secondary:focus {
+    color: #2f214e;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_metrics {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_metric_card {
+    background: #fff;
+    border: 1px solid #e5e0ef;
+    border-radius: 14px;
+    box-shadow: 0 10px 24px rgba(42, 28, 75, 0.06);
+    min-height: 118px;
+    padding: 18px 20px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_metric_label {
+    color: #79738b;
+    display: block;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_metric_value {
+    color: #2f214e;
+    display: block;
+    font-size: 24px;
+    line-height: 1.25;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_main_template {
+    background: #f4f2fa;
+    border: 1px solid #e1dcef;
+    border-radius: 18px;
+    display: grid;
+    gap: 0;
+    grid-template-columns: 290px minmax(0, 1fr);
+    overflow: hidden;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_mobile_nav {
+    align-items: center;
+    background: #fff;
+    border-bottom: 1px solid #ece8f4;
+    color: #2f214e;
+    display: none;
+    gap: 8px;
+    padding: 16px 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_mobile_nav .dashicons {
+    color: #2f214e;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_mobile_nav_label {
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_navigator_template {
+    background: linear-gradient(180deg, #2f214e 0%, #23183c 100%);
+    display: block;
+    flex: none;
+    min-width: 0;
+    padding: 22px 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidepanel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidepanel_intro h2 {
+    color: #fff;
+    font-size: 24px;
+    line-height: 1.2;
+    margin: 6px 0 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidepanel_eyebrow,
+#wps_wgm_setting_wrapper .wps_wgm_content_header_eyebrow,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_eyebrow {
+    color: #8ebcff;
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm-navigations {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs {
+    position: static;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab {
+    align-items: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 12px;
+    color: #ece8f4;
+    display: flex;
+    float: none;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 12px;
+    justify-content: space-between;
+    letter-spacing: 0;
+    line-height: 1.35;
+    margin: 0;
+    min-height: 52px;
+    padding: 12px 14px;
+    text-decoration: none;
+    text-transform: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab:hover,
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab:focus {
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active,
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active:focus,
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active:hover {
+    background: #fff;
+    border-color: #fff;
+    color: #2f214e !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active:after {
+    display: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_title {
+    min-width: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_badge {
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    color: inherit;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 6px 9px;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active .wps_wgm_nav_badge {
+    background: #f1ecff;
+    color: #5d44a8;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked {
+    opacity: 0.9;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_template {
+    background: transparent;
+    box-shadow: none;
+    color: inherit;
+    flex: none;
+    font-size: 14px;
+    line-height: 1.6;
+    min-width: 0;
+    padding: 22px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_shell {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header {
+    align-items: center;
+    background: #fff;
+    border: 1px solid #e5e0ef;
+    border-radius: 14px;
+    box-shadow: 0 10px 24px rgba(42, 28, 75, 0.06);
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    padding: 22px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy h2 {
+    color: #2f214e;
+    font-size: 36px;
+    line-height: 1.08;
+    margin: 6px 0 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade {
+    align-items: center;
+    background: #111;
+    border-radius: 999px;
+    color: #fff;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 600;
+    justify-content: center;
+    min-height: 42px;
+    padding: 0 16px;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade:hover,
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade:focus {
+    color: #fff;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_layout {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    background: #fff;
+    border: 1px solid #e5e0ef;
+    border-radius: 14px;
+    box-shadow: 0 10px 24px rgba(42, 28, 75, 0.06);
+    min-width: 0;
+    overflow: hidden;
+    padding: 22px 24px 28px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    background: #fff;
+    border: 1px solid #e5e0ef;
+    border-radius: 14px;
+    box-shadow: 0 10px 24px rgba(42, 28, 75, 0.06);
+    padding: 20px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card h3 {
+    color: #2f214e;
+    font-size: 22px;
+    line-height: 1.2;
+    margin: 8px 0 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card p {
+    color: #6e6880;
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_tint {
+    background: #fff9e9;
+    border-color: #f0dfae;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_links {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link {
+    background: #fff;
+    border: 1px solid #e3deee;
+    border-radius: 12px;
+    color: #2f214e;
+    display: block;
+    font-weight: 600;
+    padding: 13px 14px;
+    text-decoration: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link:hover,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link:focus {
+    border-color: #bbaedf;
+    color: #2f214e;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_overview_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel h3.wps_wgm_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_uwgc-license-sec-wrap h3 {
+    background: #edf6ff;
+    border-bottom: 1px solid #dbeaf7;
+    color: #2081ca;
+    font-size: 24px;
+    font-weight: 700;
+    margin: -22px -24px 24px;
+    padding: 18px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_table_wrapper,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_overview_content {
+    box-shadow: none;
+    margin-bottom: 0;
+    max-width: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel table.form-table {
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th {
+    color: #3a3550;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 22px 14px 22px 0;
+    width: 260px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+    border-top: 1px solid #efeaf7;
+    padding: 18px 0 18px 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tr:first-child td,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tr:first-child th {
+    border-top: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="text"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="email"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="number"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="password"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel textarea {
+    border: 1px solid #d6d2df;
+    border-radius: 10px;
+    box-shadow: none;
+    min-height: 42px;
+    padding: 10px 12px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel textarea {
+    min-height: 120px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container {
+    min-width: 220px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--single,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--multiple {
+    border: 1px solid #d6d2df;
+    border-radius: 10px;
+    min-height: 42px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .description {
+    color: #716b82;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_save_button,
+#wps_wgm_setting_wrapper .wps_wgm_small_button,
+#wps_wgm_setting_wrapper #wps_wgm_csv_offlinecoupon_import,
+#wps_wgm_setting_wrapper #wps_wgm_import_button,
+#wps_wgm_setting_wrapper #wps_wgm_add_new_card_button,
+#wps_wgm_setting_wrapper .resend.column-resend .wps_wgm_offline_resend_mail,
+#wps_wgm_setting_wrapper #wps_uwgc_qrcode_setting_save,
+#wps_wgm_setting_wrapper #uwgc_custom_giftcard,
+#wps_wgm_setting_wrapper #wps_uwgc-license-activate {
+    align-items: center;
+    background: #111;
+    border-radius: 999px;
+    color: #fff;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 700;
+    justify-content: center;
+    letter-spacing: 0.03em;
+    min-height: 46px;
+    padding: 0 18px;
+    text-decoration: none;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_custom_giftcard {
+    align-items: center;
+    background: #111;
+    border-radius: 999px;
+    border: none;
+    box-shadow: none;
+    color: #fff;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 700;
+    justify-content: center;
+    letter-spacing: 0.03em;
+    min-height: 46px;
+    padding: 0 18px;
+    text-shadow: none;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_custom_giftcard:hover,
+#wps_wgm_setting_wrapper #wps_wgm_custom_giftcard:focus {
+    background: #111;
+    color: #fff;
+    outline: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_save_button:hover,
+#wps_wgm_setting_wrapper .wps_wgm_save_button:focus,
+#wps_wgm_setting_wrapper .wps_wgm_small_button:hover,
+#wps_wgm_setting_wrapper .wps_wgm_small_button:focus {
+    color: #fff;
+}
+
+#wps_wgm_setting_wrapper .wps-gift-cards-pro-tag span:not(.wps_wgm_nav_badge) {
+    position: static;
+}
+
+@media only screen and (max-width: 1200px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media only screen and (max-width: 992px) {
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_banner {
+        grid-template-columns: 1fr;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_actions {
+        justify-content: flex-start;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_metrics {
+        grid-template-columns: 1fr;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_main_template {
+        grid-template-columns: 1fr;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_mobile_nav {
+        display: inline-flex;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_navigator_template {
+        display: none;
+        padding-top: 0;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_template {
+        padding: 18px;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel {
+        padding: 18px;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_overview_heading,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel h3.wps_wgm_heading,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_uwgc-license-sec-wrap h3 {
+        margin: -18px -18px 20px;
+        padding: 16px 18px;
+    }
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_header_copy h2 {
+        font-size: 28px;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tbody,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tr,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+        display: block;
+        width: 100%;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th {
+        padding: 18px 0 8px;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+        padding: 0 0 18px;
+    }
+}
+
+/* Dashboard redesign */
+#wps_wgm_setting_wrapper {
+    margin-top: 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_shell {
+    gap: 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner {
+    background: #fff5df;
+    border: 1px solid #f1e1b3;
+    border-radius: 12px;
+    box-shadow: none;
+    gap: 16px;
+    grid-template-columns: 120px minmax(0, 1fr) auto;
+    padding: 14px 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_badge {
+    align-self: center;
+    background: #ffb020;
+    font-size: 11px;
+    min-height: 32px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_copy h1 {
+    color: #2f214e;
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 4px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_banner_copy p {
+    color: #6d6680;
+    font-size: 12px;
+    line-height: 1.5;
+    max-width: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action,
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade {
+    min-height: 36px;
+    padding: 0 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_main_template {
+    background: #f4f3fb;
+    border: 1px solid #e6e2f0;
+    border-radius: 16px;
+    box-shadow: none;
+    display: block;
+    overflow: hidden;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs {
+    align-items: center;
+    background: #f7f6fb;
+    border-bottom: 1px solid #e6e2f0;
+    display: flex;
+    gap: 0;
+    overflow-x: auto;
+    padding: 0 16px;
+    white-space: nowrap;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs {
+    flex: 0 0 auto;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab {
+    background: transparent;
+    border: 0;
+    border-bottom: 3px solid transparent;
+    border-radius: 0;
+    color: #3d3650;
+    font-size: 13px;
+    font-weight: 600;
+    min-height: 58px;
+    padding: 14px 14px 11px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab:hover,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab:focus {
+    background: transparent;
+    color: #1f1a2e;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:focus,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:hover {
+    background: transparent;
+    border-bottom-color: #f0ab00;
+    color: #1f1a2e !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_badge {
+    background: #efe9ff;
+    color: #5d44a8;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_template {
+    padding: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_shell {
+    gap: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header {
+    align-items: center;
+    background: #f1edff;
+    border: 1px solid #e5defc;
+    border-radius: 12px;
+    box-shadow: none;
+    padding: 18px 20px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy h2 {
+    font-size: 24px;
+    line-height: 1.15;
+    margin: 6px 0 4px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy p {
+    color: #6f6884;
+    font-size: 13px;
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_layout {
+    align-items: start;
+    gap: 16px;
+    grid-template-columns: minmax(0, 1fr) 240px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    border: 1px solid #ebe7f4;
+    border-radius: 12px;
+    box-shadow: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    padding: 14px 18px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    padding: 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card h3 {
+    font-size: 18px;
+    margin: 0 0 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card p {
+    font-size: 13px;
+    line-height: 1.6;
+    margin: 0 0 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_tint {
+    background: #fff7e3;
+    border-color: #f0dfae;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_links {
+    gap: 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link {
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 11px 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_overview_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel h3.wps_wgm_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_uwgc-license-sec-wrap h3 {
+    background: #e8f6ff;
+    border-bottom: 0;
+    border-radius: 8px 8px 0 0;
+    color: #1f88d5;
+    font-size: 18px;
+    margin: -14px -18px 20px;
+    padding: 12px 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th {
+    border-top: 1px solid #efeaf7;
+    font-size: 13px;
+    padding: 20px 14px 20px 0;
+    width: 240px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+    padding: 16px 0 16px 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tbody tr:first-child th,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tbody tr:first-child td {
+    border-top: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="text"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="email"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="number"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="password"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel textarea {
+    border-radius: 8px;
+    min-height: 38px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_save_button,
+#wps_wgm_setting_wrapper .wps_wgm_small_button,
+#wps_wgm_setting_wrapper #wps_wgm_csv_offlinecoupon_import,
+#wps_wgm_setting_wrapper #wps_wgm_import_button,
+#wps_wgm_setting_wrapper #wps_wgm_add_new_card_button,
+#wps_wgm_setting_wrapper .resend.column-resend .wps_wgm_offline_resend_mail,
+#wps_wgm_setting_wrapper #wps_uwgc_qrcode_setting_save,
+#wps_wgm_setting_wrapper #uwgc_custom_giftcard,
+#wps_wgm_setting_wrapper #wps_uwgc-license-activate {
+    min-height: 40px;
+}
+
+#wps_wgm_setting_wrapper .wps-gc-activate_notice.update-nag {
+    background: #fff;
+    border: 1px solid #e5dff3;
+    border-radius: 12px;
+    box-shadow: none;
+    color: #32294d;
+    margin: 0;
+    padding: 16px 18px;
+}
+
+@media only screen and (max-width: 1200px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_banner {
+        grid-template-columns: 1fr;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs {
+        padding: 0 10px;
+    }
+}
+
+/* Exact settings table pass */
+#wps_wgm_setting_wrapper .wps_wgm_content_header_eyebrow,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_eyebrow {
+    color: #ffaf1f;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    background: #ffffff;
+    border-color: #ece7f6;
+    border-radius: 14px;
+    padding: 12px 14px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_wgm_overview_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel h3.wps_wgm_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wps_uwgc-license-sec-wrap h3 {
+    background: #dff1ff;
+    border-radius: 10px 10px 0 0;
+    color: #2892dd;
+    font-size: 16px;
+    line-height: 1.2;
+    margin: -12px -14px 0;
+    padding: 14px 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_template tbody tr,
+#wps_wgm_setting_wrapper .wps_wgm_content_template tbody tr:nth-of-type(even),
+#wps_wgm_setting_wrapper .wps_wgm_content_template tbody tr:nth-of-type(odd),
+#wps_wgm_setting_wrapper .wps_wgm_content_template tbody tr:hover {
+    background: #ffffff !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel table.form-table {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+    background: #ffffff;
+    border-top: 1px solid #f0edf7;
+    vertical-align: middle;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th {
+    color: #2f2a43;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.75;
+    padding: 18px 16px 18px 10px;
+    width: 210px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+    color: #6f6884;
+    font-size: 12px;
+    line-height: 1.7;
+    padding: 18px 12px 18px 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tbody tr:first-child th,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table tbody tr:first-child td {
+    border-top: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp > label,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp .wps_wgm_label,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp .wps_wgm_par_parent_wrapper,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp .select2-container,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp .description {
+    vertical-align: middle;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .forminp > label {
+    align-items: center;
+    color: #6f6884;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    max-width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .woocommerce-help-tip {
+    float: none;
+    margin: 0 8px 0 0 !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="text"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="email"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="number"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="password"],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel textarea {
+    background: #ffffff;
+    border: 1px solid #d9d3e8;
+    border-radius: 8px;
+    box-shadow: none;
+    color: #3b3551;
+    font-size: 12px;
+    max-width: 360px;
+    min-height: 34px;
+    padding: 8px 10px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel textarea {
+    min-height: 72px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select {
+    padding-right: 28px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container {
+    max-width: 520px;
+    min-width: 260px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--single,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--multiple {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #d9d3e8;
+    border-radius: 8px;
+    display: flex;
+    min-height: 34px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    background: #f2eff8;
+    border: 1px solid #ddd6ea;
+    border-radius: 4px;
+    color: #5d576e;
+    font-size: 11px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    background: #d8d7dd;
+    border: 0;
+    border-radius: 999px;
+    box-shadow: none;
+    cursor: pointer;
+    height: 18px;
+    margin: 0;
+    position: relative;
+    transition: background-color 0.2s ease;
+    width: 34px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="checkbox"]::before {
+    background: #ffffff;
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(17, 17, 17, 0.18);
+    content: "";
+    height: 14px;
+    left: 2px;
+    margin: 0;
+    position: absolute;
+    top: 2px;
+    transform: none;
+    transition: left 0.2s ease;
+    width: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="checkbox"]:checked {
+    background: #ffbe47;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel input[type="checkbox"]:checked::before {
+    background: #ffffff;
+    left: 18px;
+}
+
+#wps_wgm_setting_wrapper .giftcard_page_wps-wgc-setting-lite .wps_wgm_content_panel input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    border-radius: 999px;
+    height: 18px;
+    width: 34px;
+}
+
+#wps_wgm_setting_wrapper .giftcard_page_wps-wgc-setting-lite .wps_wgm_content_panel input[type="checkbox"]:before {
+    content: "";
+}
+
+#wps_wgm_setting_wrapper .giftcard_page_wps-wgc-setting-lite .wps_wgm_content_panel input[type="checkbox"]:checked {
+    background: #ffbe47;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .description,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel p,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel label {
+    font-size: 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .submit {
+    margin: 18px 0 0;
+    padding: 0 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_save_button {
+    min-height: 38px;
+    padding: 0 18px;
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table th {
+        padding: 16px 0 8px;
+        width: 100%;
+    }
+
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel .form-table td {
+        padding: 0 0 16px;
+    }
+}
+
+/* Final shell override to match reference */
+#wps_wgm_setting_wrapper {
+    margin-top: 6px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_shell {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_page_notice {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #d8d4e3;
+    border-left: 4px solid #17b34a;
+    box-shadow: none;
+    display: flex;
+    justify-content: space-between;
+    margin: 0;
+    min-height: 46px;
+    padding: 10px 14px 10px 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_page_notice p {
+    color: #1f1a44;
+    font-size: 13px;
+    line-height: 1.5;
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_page_notice .notice-dismiss {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: #7d7690;
+    cursor: pointer;
+    display: inline-flex;
+    height: 24px;
+    justify-content: center;
+    padding: 0;
+    position: static;
+    width: 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_page_notice .notice-dismiss:before {
+    color: inherit;
+    font-size: 18px;
+    line-height: 1;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice {
+    align-items: center;
+    border-radius: 14px;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding: 12px 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_promo {
+    background: #fff6df;
+    border: 1px solid #eeddb2;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_status {
+    background: #2f154e;
+    border: 1px solid #2f154e;
+    color: #ffffff;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_badge {
+    align-items: center;
+    background: #ffb128;
+    border-radius: 999px;
+    color: #ffffff;
+    display: inline-flex;
+    font-size: 10px;
+    font-weight: 700;
+    justify-content: center;
+    min-height: 28px;
+    padding: 0 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_badge_dark {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_copy strong {
+    color: inherit;
+    display: block;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_copy p {
+    color: inherit;
+    font-size: 10px;
+    line-height: 1.4;
+    margin: 2px 0 0;
+    opacity: 0.75;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_dismiss {
+    background: #111111;
+    border: 0;
+    border-radius: 8px;
+    color: #ffffff;
+    cursor: pointer;
+    font-size: 10px;
+    font-weight: 600;
+    min-height: 28px;
+    padding: 0 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_meta {
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 10px;
+    font-weight: 600;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_row .wps-gc-activate_notice.update-nag {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #e4ddf1;
+    border-radius: 14px;
+    box-shadow: none;
+    color: #2e2a48;
+    display: flex;
+    font-size: 12px;
+    line-height: 1.5;
+    margin: 0;
+    min-height: 54px;
+    padding: 12px 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_row .wps-gc-activate_notice.update-nag:before {
+    align-items: center;
+    background: #fff1f4;
+    border-radius: 50%;
+    color: #ff6b81;
+    content: "!";
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 700;
+    height: 24px;
+    justify-content: center;
+    margin-right: 12px;
+    min-width: 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_row .wps-gc-activate_notice.update-nag strong,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_row .wps-gc-activate_notice.update-nag a {
+    color: #2e2a48;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_main_template {
+    background: #f4f3fb;
+    border: 1px solid #e6e2f0;
+    border-radius: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs {
+    align-items: center;
+    background: #fbfbff;
+    border: 0;
+    border-bottom: 1px solid #e6e2f0;
+    border-radius: 14px 14px 0 0;
+    display: flex;
+    overflow: visible;
+    padding: 0 16px;
+    position: relative;
+    white-space: nowrap;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs {
+    flex: 0 0 auto;
+    position: relative;
+    z-index: 1;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab {
+    border-bottom: 3px solid transparent;
+    color: #312c45;
+    font-size: 12px;
+    font-weight: 600;
+    min-height: 54px;
+    padding: 14px 14px 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:focus,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:hover {
+    border-bottom-color: #f0ab00;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_badge {
+    background: #efe9ff;
+    border-radius: 999px;
+    color: #5d44a8;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    margin-left: 8px;
+    padding: 4px 7px;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked {
+    opacity: 0.9;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_more {
+    align-items: center;
+    display: inline-flex;
+    gap: 6px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_caret {
+    font-size: 9px;
+    line-height: 1;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_more {
+    position: relative;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu {
+    background: #ffffff;
+    border: 1px solid #e4ddf1;
+    border-radius: 12px;
+    box-shadow: 0 10px 24px rgba(39, 28, 77, 0.12);
+    display: none;
+    gap: 6px;
+    min-width: 220px;
+    padding: 8px;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 8px);
+    z-index: 20;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_more.is-open .wps_wgm_more_menu {
+    display: flex;
+    flex-direction: column;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link {
+    align-items: center;
+    border-radius: 8px;
+    color: #312c45;
+    display: flex;
+    font-size: 12px;
+    font-weight: 500;
+    justify-content: space-between;
+    padding: 10px 12px;
+    text-decoration: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link:hover,
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link:focus {
+    background: #f5f1ff;
+    color: #231d39;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link.is-active {
+    align-self: flex-start;
+    background: #fff3d8;
+    border-radius: 12px;
+    color: #231d39;
+    display: flex;
+    gap: 8px;
+    margin: 0 10px;
+    width: calc(100% - 20px);
+    padding: 8px 14px 12px;
+    position: relative;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link.is-active::after {
+    background: #f0a200;
+    border-radius: 999px;
+    bottom: 4px;
+    content: "";
+    height: 3px;
+    left: 14px;
+    position: absolute;
+    right: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link.is-locked {
+    opacity: 0.95;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_template {
+    padding: 22px 10px 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_layout {
+    gap: 14px;
+    grid-template-columns: minmax(0, 1fr) 250px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header {
+    background: #f3efff;
+    border: 1px solid #e5def8;
+    border-radius: 14px;
+    padding: 16px 20px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy {
+    max-width: 620px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_eyebrow {
+    color: #ffb128;
+    font-size: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy h2 {
+    color: #2b254e;
+    font-size: 28px;
+    font-weight: 700;
+    line-height: 1.05;
+    margin: 6px 0 6px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy p {
+    color: #736d88;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action,
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade {
+    background: #111111;
+    border: 0;
+    border-radius: 999px;
+    color: #ffffff;
+    font-size: 10px;
+    font-weight: 600;
+    min-height: 34px;
+    padding: 0 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    background: #ffffff;
+    border: 1px solid #ebe7f4;
+    border-radius: 12px;
+    padding: 12px 14px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    background: #ffffff;
+    border: 1px solid #ebe7f4;
+    border-radius: 12px;
+    padding: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card h3 {
+    color: #2d2753;
+    font-size: 14px;
+    line-height: 1.35;
+    margin: 0 0 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card p {
+    color: #78728d;
+    font-size: 11px;
+    line-height: 1.6;
+    margin: 0 0 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link {
+    background: #ffffff;
+    border: 1px solid #e4ddf1;
+    border-radius: 10px;
+    color: #514a67;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 10px 12px;
+}
+
+@media only screen and (max-width: 1200px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper .wps_wgm_dashboard_notice {
+        grid-template-columns: 1fr;
+        justify-items: start;
+    }
+}
+
+/* Saved notice alignment inside tab panels */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice {
+    border: 0;
+    border-radius: 12px;
+    box-shadow: none;
+    margin: 0 0 18px;
+    min-height: 52px;
+    padding: 14px 48px 14px 48px;
+    position: relative;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice::before,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice::before {
+    background: currentColor;
+    border-radius: 999px;
+    content: "";
+    height: 10px;
+    left: 18px;
+    opacity: 0.14;
+    position: absolute;
+    top: 21px;
+    width: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice.notice-success,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice.notice-success,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice.updated {
+    background: linear-gradient(180deg, #f4fff7 0%, #ecfbf1 100%);
+    color: #1f6f43;
+    outline: 1px solid #c9ead5;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice.notice-error,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .update-nag,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice.update-nag {
+    background: linear-gradient(180deg, #fff7f5 0%, #fff0ec 100%);
+    color: #b43d2a;
+    outline: 1px solid #f2c5bc;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice p,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice p {
+    color: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.5;
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice p strong,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice p strong {
+    color: inherit;
+    font-size: inherit;
+    font-weight: 600;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice .notice-dismiss,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice .notice-dismiss {
+    align-items: center;
+    background: rgba(17, 17, 17, 0.06);
+    border-radius: 999px;
+    display: inline-flex;
+    height: 26px;
+    justify-content: center;
+    padding: 0;
+    right: 14px;
+    top: 13px;
+    transition: background 0.2s ease, color 0.2s ease;
+    width: 26px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice .notice-dismiss:before,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice .notice-dismiss:before {
+    color: inherit;
+    font-size: 15px;
+    line-height: 26px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice .notice-dismiss:hover,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice .notice-dismiss:focus,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice .notice-dismiss:hover,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice .notice-dismiss:focus {
+    background: rgba(17, 17, 17, 0.12);
+    color: inherit;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice + .wps_wgm_overview_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .notice + h3.wps_wgm_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice + .wps_wgm_overview_heading,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .updated.notice + h3.wps_wgm_heading {
+    margin-top: 0;
+}
+
+/* Final native select cleanup across all settings tabs */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select {
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: #ffffff;
+    background-image:
+        linear-gradient(45deg, transparent 50%, #6f6884 50%),
+        linear-gradient(135deg, #6f6884 50%, transparent 50%);
+    background-position:
+        calc(100% - 16px) calc(50% - 2px),
+        calc(100% - 11px) calc(50% - 2px);
+    background-repeat: no-repeat;
+    background-size: 6px 6px, 6px 6px;
+    border: 1px solid #d9d3e8;
+    border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(33, 16, 74, 0.04);
+    color: #2f2943;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.4;
+    min-height: 42px;
+    padding: 10px 38px 10px 12px !important;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select:hover {
+    border-color: #c8bfdc;
+    background-color: #fcfbfe;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select:focus {
+    border-color: #7b61ff;
+    box-shadow: 0 0 0 3px rgba(123, 97, 255, 0.12);
+    outline: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select option {
+    background: #ffffff;
+    color: #2f2943;
+    font-size: 13px;
+    padding: 10px 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select option:checked {
+    background: #ece9f4 linear-gradient(0deg, #ece9f4, #ece9f4);
+    color: #2f2943;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select option:hover,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel select option:focus {
+    background: #dfe7fb linear-gradient(0deg, #dfe7fb, #dfe7fb);
+    color: #2f2943;
+}
+
+/* Final Select2 cleanup across all settings tabs */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container {
+    max-width: 520px !important;
+    min-width: 260px;
+    width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--single,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container .select2-selection--multiple,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices {
+    align-items: flex-start;
+    background: #ffffff;
+    border: 1px solid #d9d3e8;
+    border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(33, 16, 74, 0.04);
+    min-height: 42px;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-active .select2-choices,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container--focus .select2-selection--single,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container--focus .select2-selection--multiple {
+    border-color: #7b61ff;
+    box-shadow: 0 0 0 3px rgba(123, 97, 255, 0.12);
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0;
+    overflow: hidden;
+    padding: 6px 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices .select2-search-field {
+    float: none;
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices .select2-search-field input,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-search--inline .select2-search__field {
+    background: #ffffff !important;
+    border: 1px solid #ddd6ea !important;
+    border-radius: 8px;
+    box-shadow: none !important;
+    color: #2f2943;
+    font-size: 13px;
+    height: 34px;
+    margin: 0 !important;
+    min-width: 160px;
+    padding: 0 12px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices .select2-search-choice,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    align-items: center;
+    background: #f2eff8;
+    border: 1px solid #ddd6ea;
+    border-radius: 999px;
+    box-shadow: none;
+    color: #5b536f;
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 500;
+    gap: 4px;
+    line-height: 1.2;
+    margin: 0;
+    padding: 5px 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices .select2-search-choice .select2-search-choice-close,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    color: #7a738b;
+    float: none;
+    font-size: 12px;
+    font-weight: 700;
+    left: auto;
+    margin: 0;
+    position: static;
+    top: auto;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-container-multi .select2-choices .select2-search-choice div {
+    margin: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-drop,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-dropdown,
+#select2-drop,
+.select2-dropdown {
+    background: #ffffff;
+    border: 1px solid #d9d3e8;
+    border-radius: 10px;
+    box-shadow: 0 18px 36px rgba(44, 27, 87, 0.12);
+    overflow: hidden;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results__options,
+.select2-results,
+.select2-results__options {
+    margin: 0;
+    padding: 6px 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results .select2-result-label,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results__option,
+.select2-results .select2-result-label,
+.select2-results__option {
+    color: #2f2943;
+    font-size: 13px;
+    line-height: 1.4;
+    padding: 10px 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results .select2-highlighted,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results__option--highlighted[aria-selected],
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results__option--highlighted[data-selected],
+.select2-results .select2-highlighted,
+.select2-results__option--highlighted[aria-selected],
+.select2-results__option--highlighted[data-selected] {
+    background: #e9eefb !important;
+    color: #2f2943 !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .select2-results .select2-selected,
+.select2-results .select2-selected {
+    background: #f2eff8;
+    color: #5b536f;
+}
+
+/* Final shell pass to match the provided dashboard reference */
+#wps_wgm_setting_wrapper {
+    margin-top: 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_shell {
+    gap: 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_stack {
+    display: flex;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_status {
+    background: #321451;
+    border-color: #321451;
+    border-radius: 18px;
+    min-height: 54px;
+    padding: 8px 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_badge_dark {
+    background: rgba(255, 255, 255, 0.14);
+    min-height: 30px;
+    padding: 0 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_copy strong {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_notice_meta {
+    font-size: 11px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_main_template {
+    background: #f4f3fb;
+    border: 1px solid #e9e5f2;
+    border-radius: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs {
+    align-items: stretch;
+    background: #ffffff;
+    border-bottom: 1px solid #ebe7f2;
+    border-radius: 18px 18px 0 0;
+    gap: 0;
+    padding: 0 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_meta {
+    align-items: center;
+    color: #857d97;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-size: 13px;
+    font-weight: 600;
+    padding-right: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_version {
+    display: inline-flex;
+    min-height: 50px;
+    padding: 17px 0 13px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab {
+    color: #6a647d;
+    font-size: 12px;
+    font-weight: 600;
+    min-height: 50px;
+    padding: 14px 14px 11px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:focus,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:hover {
+    color: #262145;
+    border-bottom-color: #f0a400;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_badge {
+    background: #59c76d;
+    border-radius: 4px;
+    color: #ffffff;
+    font-size: 9px;
+    margin-left: 6px;
+    padding: 2px 5px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_more {
+    gap: 5px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_caret {
+    color: #6d6781;
+    font-size: 8px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_template {
+    padding: 22px 18px 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_shell {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header {
+    background: #f7f5ff;
+    border: 1px solid #eae4f8;
+    border-radius: 20px;
+    padding: 18px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy {
+    max-width: 720px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_eyebrow {
+    color: #ffab1f;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy h2 {
+    color: #27224d;
+    font-size: 33px;
+    font-weight: 700;
+    margin: 7px 0 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_header_copy p {
+    color: #716b85;
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_action,
+#wps_wgm_setting_wrapper .wps_wgm_inline_upgrade {
+    border-radius: 14px;
+    font-size: 12px;
+    font-weight: 700;
+    min-height: 40px;
+    padding: 0 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_layout {
+    gap: 22px;
+    grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    border-radius: 20px;
+    padding: 18px 18px 26px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    border-radius: 18px;
+    padding: 18px 16px 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card + .wps_wgm_sidebar_card {
+    margin-top: 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_tint {
+    background: #fff8ea;
+    border-color: #f1e0b7;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card h3 {
+    font-size: 14px;
+    font-weight: 700;
+    margin: 0 0 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card p {
+    font-size: 12px;
+    line-height: 1.65;
+    margin: 0 0 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_links {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link {
+    align-items: center;
+    border-radius: 12px;
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 600;
+    justify-content: flex-start;
+    min-height: 42px;
+    padding: 0 14px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary {
+    background: #111111;
+    border-color: #111111;
+    color: #ffffff;
+    justify-content: center;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:hover,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:focus {
+    color: #ffffff;
+}
+
+/* Mail image upload row layout */
+#wps_wgm_setting_wrapper tr.wps_wgm_mail_setting_background_logo td.forminp.forminp-text,
+#wps_wgm_setting_wrapper tr.wps_wgm_mail_setting_upload_logo td.forminp.forminp-text {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_background_logo_value,
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_upload_logo {
+    flex: 1 1 420px;
+    margin: 0 !important;
+    max-width: 100%;
+    min-width: 280px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_mail_setting_background_logo.button,
+#wps_wgm_setting_wrapper .wps_wgm_mail_setting_upload_logo.button {
+    align-items: center;
+    display: inline-flex;
+    flex: 0 0 auto;
+    justify-content: center;
+    margin: 0 !important;
+    min-height: 42px;
+    padding: 0 18px;
+    white-space: nowrap;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_remove_background,
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_remove_logo {
+    margin: 4px 0 0;
+    padding: 0;
+    width: 100%;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_remove_background > span,
+#wps_wgm_setting_wrapper #wps_wgm_mail_setting_remove_logo > span {
+    align-items: center;
+    column-gap: 14px;
+    display: inline-flex;
+    flex-wrap: wrap;
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper #wps_wgm_mail_setting_background_logo_value,
+    #wps_wgm_setting_wrapper #wps_wgm_mail_setting_upload_logo {
+        flex-basis: 100%;
+        min-width: 100%;
+    }
+}
+
+/* Locked tabs should match normal tab layout */
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab_locked {
+    background: transparent;
+    border-radius: 0;
+    color: #6c6681;
+    gap: 6px;
+    margin: 0;
+    min-height: 72px !important;
+    padding: 0 14px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab_locked:hover,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab_locked:focus {
+    background: transparent;
+    color: #28234a;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked:hover,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked:focus {
+    background: transparent;
+    border-bottom-color: #f0a11e;
+    color: #28234a;
+}
+
+/* Offline Add New button should match Import button exactly */
+#wps_wgm_setting_wrapper #wps_wgm_add_new_card_button.wps_wgm_add_new_card_button_org.page-title-action {
+    align-items: center;
+    background: #111111;
+    border: 0;
+    border-radius: 999px;
+    box-shadow: none;
+    color: #ffffff;
+    display: inline-flex;
+    float: right;
+    font-size: 13px;
+    font-weight: 700;
+    justify-content: center;
+    letter-spacing: 0.03em;
+    line-height: 1;
+    margin: 13px 0 0;
+    min-height: 40px;
+    min-width: 96px;
+    padding: 0 18px;
+    text-decoration: none;
+    text-shadow: none;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_add_new_card_button.wps_wgm_add_new_card_button_org.page-title-action:hover,
+#wps_wgm_setting_wrapper #wps_wgm_add_new_card_button.wps_wgm_add_new_card_button_org.page-title-action:focus {
+    background: #111111;
+    color: #ffffff;
+}
+
+/* Full-width WordPress editor inside settings rows */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel td.forminp.forminp-text > label:has(.wp-editor-wrap) {
+    display: block;
+    width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wp-editor-wrap,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wp-editor-container,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .quicktags-toolbar,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .mce-toolbar-grp {
+    max-width: none !important;
+    width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wp-editor-wrap {
+    min-width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .tmce-active .wp-editor-area,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .html-active .wp-editor-area,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wp-editor-area {
+    width: 100% !important;
+    max-width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .wp-editor-wrap iframe {
+    width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel .html-active textarea.wp-editor-area {
+    box-sizing: border-box;
+    display: block;
+    min-width: 100%;
+    width: 100% !important;
+}
+
+/* Product setting org multiselect cleanup */
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category {
+    width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2-container,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2-container,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2 {
+    max-width: 560px !important;
+    width: 100% !important;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2-container .select2-selection--multiple,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2-container .select2-selection--multiple,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2 .select2-selection--multiple,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2 .select2-selection--multiple {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 62px;
+    padding: 8px 10px;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2-container .select2-selection__rendered,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2-container .select2-selection__rendered,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2 .select2-selection__rendered,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2 .select2-selection__rendered {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2-container .select2-selection__choice,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2-container .select2-selection__choice,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2 .select2-selection__choice,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2 .select2-selection__choice {
+    background: #f5f2fa !important;
+    border: 1px solid #ddd6ea !important;
+    border-radius: 999px !important;
+    color: #5a536d !important;
+    font-size: 12px !important;
+    line-height: 1.2;
+    margin: 0 !important;
+    max-width: 100%;
+    padding: 6px 10px !important;
+}
+
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2-container .select2-search--inline .select2-search__field,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2-container .select2-search--inline .select2-search__field,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_product + .select2 .select2-search--inline .select2-search__field,
+#wps_wgm_setting_wrapper #wps_wgm_product_setting_exclude_category + .select2 .select2-search--inline .select2-search__field {
+    height: 34px;
+    min-width: 180px;
+    padding: 0 10px !important;
+}
+
+/* QR/Barcode buttons equal size */
+#wps_wgm_setting_wrapper .wps_wgm_button_wrapper > p.submit {
+    align-items: center;
+    display: inline-flex;
+    gap: 14px;
+}
+
+#wps_wgm_setting_wrapper #wps_uwgc_save_qrcode_org,
+#wps_wgm_setting_wrapper #wps_uwgc_qrcode_setting_save {
+    align-items: center;
+    background: #111111;
+    border: 0;
+    border-radius: 18px;
+    color: #ffffff;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 700;
+    justify-content: center;
+    line-height: 1;
+    min-height: 48px;
+    min-width: 150px;
+    padding: 0 22px;
+    text-align: center;
+}
+
+/* Final floating save button visual match */
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    padding-bottom: 110px !important;
+}
+
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit {
+    background: #ffffff !important;
+    border: 1px solid #ece8f4 !important;
+    border-radius: 20px !important;
+    bottom: 22px !important;
+    box-shadow: 0 8px 18px rgba(18, 12, 35, 0.12) !important;
+    left: 170px !important;
+    margin: 0 !important;
+    padding: 10px 14px !important;
+    position: fixed !important;
+    width: auto !important;
+    z-index: 99999 !important;
+}
+
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit .wps_wgm_save_button {
+    background: #111111 !important;
+    border: 0 !important;
+    border-radius: 16px !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.16) !important;
+    color: #ffffff !important;
+    font-size: 13px !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.08em !important;
+    line-height: 1 !important;
+    margin: 0 !important;
+    min-height: 48px !important;
+    min-width: 160px !important;
+    padding: 0 22px !important;
+    text-transform: uppercase !important;
+}
+
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit .wps_wgm_save_button:hover,
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit .wps_wgm_save_button:focus {
+    color: #ffffff !important;
+}
+
+@media only screen and (max-width: 960px) {
+    body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit {
+        bottom: 14px !important;
+        left: 14px !important;
+    }
+}
+
+/* Forced floating save button */
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    padding-bottom: 110px !important;
+}
+
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit {
+    background: rgba(255, 255, 255, 0.97) !important;
+    border: 1px solid #e7e2f2 !important;
+    border-radius: 18px !important;
+    bottom: 22px !important;
+    box-shadow: 0 14px 32px rgba(34, 22, 71, 0.14) !important;
+    left: 170px !important;
+    margin: 0 !important;
+    padding: 12px 14px !important;
+    position: fixed !important;
+    width: fit-content !important;
+    z-index: 99999 !important;
+}
+
+body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit .wps_wgm_save_button {
+    margin: 0 !important;
+}
+
+@media only screen and (max-width: 960px) {
+    body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_floating_submit {
+        bottom: 14px !important;
+        left: 14px !important;
+    }
+}
+
+/* Final floating save button */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    padding-bottom: 104px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit {
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #e7e2f2;
+    border-radius: 18px;
+    bottom: 24px;
+    box-shadow: 0 14px 32px rgba(34, 22, 71, 0.14);
+    left: 176px;
+    margin: 0;
+    padding: 12px 14px;
+    position: fixed;
+    width: fit-content;
+    z-index: 999;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit .wps_wgm_save_button,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit .wps_wgm_save_button {
+    margin: 0;
+}
+
+@media only screen and (max-width: 960px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit {
+        bottom: 16px;
+        left: 16px;
+    }
+}
+
+/* Save button exact bottom-row alignment */
+#wps_wgm_setting_wrapper .wps_wgm_content_panel {
+    padding-bottom: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit {
+    backdrop-filter: blur(10px);
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid #e7e2f2;
+    border-radius: 18px;
+    bottom: 18px;
+    box-shadow: 0 14px 32px rgba(34, 22, 71, 0.12);
+    clear: both;
+    left: 18px;
+    margin: 0;
+    padding: 12px 14px;
+    position: sticky;
+    width: fit-content;
+    z-index: 20;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit .wps_wgm_save_button,
+#wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit .wps_wgm_save_button {
+    margin: 0;
+}
+
+@media only screen and (max-width: 767px) {
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel > p.submit,
+    #wps_wgm_setting_wrapper .wps_wgm_content_panel > .submit {
+        bottom: 12px;
+        left: 12px;
+        right: 12px;
+        width: auto;
+    }
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_save_button {
+    border-radius: 14px;
+    font-size: 13px;
+    font-weight: 700;
+    min-height: 40px;
+    min-width: 126px;
+    text-transform: uppercase;
+}
+
+/* Exact tab/menu styling pass */
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs {
+    align-items: stretch;
+    background: #ffffff;
+    border-bottom: 1px solid #e9e4f2;
+    border-radius: 0;
+    min-height: 72px;
+    padding: 0 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_meta {
+    align-items: center;
+    color: #827b96;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-size: 13px;
+    font-weight: 700;
+    padding: 0 12px 0 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_version {
+    align-items: center;
+    display: inline-flex;
+    min-height: 72px;
+    padding: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs {
+    align-items: stretch;
+    display: inline-flex;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_tab {
+    align-items: center;
+    border-bottom: 3px solid transparent;
+    color: #6c6681;
+    display: inline-flex;
+    font-size: 13px;
+    font-weight: 600;
+    gap: 6px;
+    min-height: 72px;
+    padding: 0 14px;
+    position: relative;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:focus,
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_tabs .nav-tab-active:hover {
+    color: #28234a;
+    border-bottom-color: #f2a100;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked {
+    border-radius: 999px;
+    color: #6b657f;
+    gap: 4px;
+    margin: 15px 4px;
+    min-height: 42px !important;
+    padding: 0 14px !important;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked .wps_wgm_nav_tab_title {
+    color: inherit;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_tabs .wps_wgm_nav_badge {
+    align-items: center;
+    background: #83ef93;
+    border-radius: 4px;
+    color: #208335;
+    display: inline-flex;
+    font-size: 9px;
+    font-weight: 700;
+    line-height: 1;
+    margin-left: 2px;
+    min-height: 18px;
+    padding: 0 5px;
+    text-transform: uppercase;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked:hover,
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_locked:focus {
+    background: #fff6de;
+    color: #28234a;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked,
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked:hover,
+#wps_wgm_setting_wrapper .wps_wgm_tabs .nav-tab-active.wps_wgm_nav_tab_locked:focus {
+    background: #fff6de;
+    border-bottom-color: transparent;
+    color: #28234a;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_nav_tab_more {
+    gap: 6px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_caret {
+    color: #746e88;
+    font-size: 8px;
+    line-height: 1;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_more {
+    margin-left: 2px;
+    position: relative;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu {
+    background: #ffffff;
+    border: 1px solid #e7e1f0;
+    border-radius: 0 0 20px 20px;
+    box-shadow: 0 16px 30px rgba(38, 26, 73, 0.08);
+    display: none;
+    gap: 0;
+    min-width: 220px;
+    padding: 12px 0;
+    position: absolute;
+    right: -10px;
+    top: calc(100% - 1px);
+    z-index: 30;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_tabs_more.is-open .wps_wgm_more_menu {
+    display: flex;
+    flex-direction: column;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link {
+    align-items: center;
+    border-radius: 0;
+    color: #6c6681;
+    display: flex;
+    font-size: 13px;
+    font-weight: 600;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 0 22px;
+    text-decoration: none;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link:hover,
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link:focus,
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link.is-active {
+    background: transparent;
+    color: #28234a;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_more_menu_link.is-locked .wps_wgm_nav_badge {
+    margin-left: 10px;
+}
+
+/* Sidebar cards exact visual pass */
+#wps_wgm_setting_wrapper .wps_wgm_dashboard_sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card {
+    background: #ffffff;
+    border: 1px solid #e9e3f4;
+    border-radius: 24px;
+    box-shadow: none;
+    padding: 22px 20px 20px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card + .wps_wgm_sidebar_card {
+    margin-top: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_tint {
+    background: #fff7ea;
+    border-color: #f1dfb5;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card h3 {
+    color: #1f1a44;
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1.25;
+    margin: 0 0 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card p {
+    color: #6f6982;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.85;
+    margin: 0 0 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_links {
+    gap: 12px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link {
+    background: #ffffff;
+    border: 1px solid #e6e0f2;
+    border-radius: 18px;
+    color: #262146;
+    display: inline-flex;
+    font-size: 15px;
+    font-weight: 700;
+    justify-content: flex-start;
+    min-height: 56px;
+    padding: 0 18px;
+    text-decoration: none;
+    width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link:hover,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link:focus {
+    color: #262146;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary {
+    background: #000000;
+    border-color: #000000;
+    border-radius: 18px;
+    color: #ffffff;
+    justify-content: center;
+    min-height: 52px;
+    padding: 0 20px;
+    width: auto;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:hover,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:focus {
+    color: #ffffff;
 }

--- a/admin/css/wpswings-onboarding-admin.css
+++ b/admin/css/wpswings-onboarding-admin.css
@@ -421,3 +421,637 @@ input[type="text"] {
 
 /*end of deactivating popup css*/
 
+/* Final onboarding modal redesign to match the dashboard shell */
+.wps-onboarding-section {
+  align-items: flex-start;
+  backdrop-filter: blur(2px);
+  background: rgba(23, 16, 42, 0.36);
+  justify-content: center;
+  padding: 32px 18px;
+  z-index: 100000;
+}
+
+.wps-on-boarding-wrapper-background {
+  max-width: 860px;
+  padding: 0;
+  transform: translateY(-24px);
+}
+
+.onboard-popup-show {
+  display: flex;
+  transform: translateY(0);
+}
+
+.wps-on-boarding-wrapper {
+  background: #ffffff;
+  border: 1px solid #ece7f7;
+  border-radius: 18px;
+  box-shadow: 0 28px 80px rgba(28, 18, 56, 0.18);
+  padding: 30px 38px 34px;
+  position: relative;
+}
+
+.wps-on-boarding-close-btn {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #e3deef;
+  border-radius: 999px;
+  box-shadow: 0 8px 22px rgba(24, 12, 54, 0.12);
+  display: inline-flex;
+  height: 38px;
+  justify-content: center;
+  right: 24px;
+  top: 22px;
+  width: 38px;
+}
+
+.wps-on-boarding-close-btn a {
+  color: #7a738b;
+  display: inline-flex;
+  font-size: 0;
+  height: 100%;
+  justify-content: center;
+  text-decoration: none;
+  width: 100%;
+}
+
+.wps-on-boarding-close-btn .close-form {
+  color: inherit;
+  font-size: 0;
+  line-height: 1;
+}
+
+.wps-on-boarding-close-btn .close-form::before {
+  content: "\00d7";
+  font-size: 26px;
+  line-height: 36px;
+}
+
+.wps-on-boarding-heading {
+  color: #241f45;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 4px auto 10px;
+  max-width: 420px;
+}
+
+.wps-on-boarding-desc {
+  color: #726b84;
+  font-size: 16px;
+  line-height: 1.65;
+  margin: 0 auto 28px;
+  max-width: 620px;
+  padding: 0;
+}
+
+.wps-on-boarding-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.wps-customer-data-form-single-field {
+  align-items: flex-start;
+  border-top: 1px solid #eee9f8;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(220px, 0.9fr) minmax(0, 1fr);
+  padding: 22px 0;
+}
+
+.wps-customer-data-form-single-field:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.on-boarding-label {
+  color: #241f45;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 240px;
+}
+
+.on-boarding-field-label {
+  color: #534d67;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.wps-on-boarding-radio-wrapper,
+.wps-on-boarding-checkbox-wrapper {
+  align-items: center;
+  display: inline-flex;
+  gap: 10px;
+  margin: 0 18px 12px 0;
+  max-width: none;
+  min-height: 24px;
+  vertical-align: top;
+  width: auto;
+}
+
+.wps-on-boarding-radio-wrapper input[type="radio"],
+.wps-on-boarding-checkbox-wrapper input[type="checkbox"] {
+  margin: 0 !important;
+}
+
+.wps-on-boarding-wrapper input[type="text"],
+.wps-on-boarding-wrapper input[type="email"],
+.wps-on-boarding-wrapper input[type="tel"],
+.wps-on-boarding-wrapper textarea,
+.wps-on-boarding-wrapper .on-boarding-select-field {
+  background: #ffffff;
+  border: 1px solid #d9d3e8;
+  border-radius: 12px;
+  box-shadow: none;
+  color: #312b45;
+  font-size: 14px;
+  max-width: 100% !important;
+  min-height: 50px;
+  padding: 12px 16px !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  width: 100% !important;
+}
+
+.wps-on-boarding-wrapper textarea {
+  min-height: 96px;
+}
+
+.wps-on-boarding-wrapper input[type="text"]:focus,
+.wps-on-boarding-wrapper input[type="email"]:focus,
+.wps-on-boarding-wrapper input[type="tel"]:focus,
+.wps-on-boarding-wrapper textarea:focus,
+.wps-on-boarding-wrapper .on-boarding-select-field:focus {
+  border-color: #7b61ff;
+  box-shadow: 0 0 0 3px rgba(123, 97, 255, 0.12);
+  outline: none;
+}
+
+.wps-on-boarding-wrapper .on-boarding-select-field {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #6f6884 50%),
+    linear-gradient(135deg, #6f6884 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) calc(50% - 2px),
+    calc(100% - 13px) calc(50% - 2px);
+  background-repeat: no-repeat;
+  background-size: 6px 6px, 6px 6px;
+  padding-right: 40px !important;
+}
+
+.wps-on-boarding-wrapper .select2-container,
+.wps-on-boarding-wrapper span.select2.select2-container.select2-container--default {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+.wps-on-boarding-wrapper .select2-container .select2-selection--single,
+.wps-on-boarding-wrapper .select2-container .select2-selection--multiple,
+.wps-on-boarding-wrapper .select2-container-multi .select2-choices {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #d9d3e8;
+  border-radius: 12px;
+  box-shadow: none;
+  min-height: 50px;
+  padding: 6px 12px;
+}
+
+.wps-on-boarding-wrapper .select2-container--focus .select2-selection--single,
+.wps-on-boarding-wrapper .select2-container--focus .select2-selection--multiple,
+.wps-on-boarding-wrapper .select2-container-active .select2-choices {
+  border-color: #7b61ff;
+  box-shadow: 0 0 0 3px rgba(123, 97, 255, 0.12);
+}
+
+.wps-on-boarding-wrapper .select2-container-multi .select2-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+}
+
+.wps-on-boarding-wrapper .select2-search-field,
+.wps-on-boarding-wrapper li.select2-search.select2-search--inline {
+  margin: 0;
+  width: auto !important;
+}
+
+.wps-on-boarding-wrapper .select2-search-field input,
+.wps-on-boarding-wrapper input.select2-search__field {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 8px;
+  box-shadow: none !important;
+  color: #312b45 !important;
+  font-size: 14px;
+  height: 34px;
+  margin: 0 !important;
+  min-width: 160px;
+  padding: 0 6px !important;
+  width: auto !important;
+}
+
+.wps-on-boarding-wrapper .select2-search-choice,
+.wps-on-boarding-wrapper .select2-selection__choice {
+  align-items: center;
+  background: #f2eff8 !important;
+  border: 1px solid #ddd6ea !important;
+  border-radius: 999px !important;
+  box-shadow: none !important;
+  color: #5b536f !important;
+  display: inline-flex;
+  filter: none !important;
+  font-size: 12px !important;
+  font-weight: 500;
+  gap: 4px;
+  margin: 0 !important;
+  padding: 6px 10px !important;
+  text-align: left;
+}
+
+.wps-on-boarding-wrapper .select2-search-choice div {
+  margin-left: 0;
+}
+
+.wps-on-boarding-wrapper .select2-search-choice-close,
+.wps-on-boarding-wrapper .select2-selection__choice__remove {
+  color: #7a738b !important;
+  left: auto !important;
+  margin: 0;
+  position: static !important;
+  top: auto !important;
+}
+
+.wps-on-boarding-wrapper .select2-drop,
+.wps-on-boarding-wrapper .select2-dropdown,
+#select2-drop,
+.select2-dropdown {
+  background: #ffffff;
+  border: 1px solid #d9d3e8;
+  border-radius: 12px;
+  box-shadow: 0 20px 44px rgba(30, 16, 64, 0.16);
+  overflow: hidden;
+}
+
+.wps-on-boarding-wrapper .select2-results,
+.wps-on-boarding-wrapper .select2-results__options,
+.select2-results,
+.select2-results__options {
+  margin: 0;
+  padding: 6px 0;
+}
+
+.wps-on-boarding-wrapper .select2-results .select2-result-label,
+.wps-on-boarding-wrapper .select2-results__option,
+.select2-results .select2-result-label,
+.select2-results__option {
+  color: #312b45;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 10px 14px;
+}
+
+.wps-on-boarding-wrapper .select2-results .select2-highlighted,
+.wps-on-boarding-wrapper .select2-results__option--highlighted[aria-selected],
+.wps-on-boarding-wrapper .select2-results__option--highlighted[data-selected],
+.select2-results .select2-highlighted,
+.select2-results__option--highlighted[aria-selected],
+.select2-results__option--highlighted[data-selected] {
+  background: #e9eefb !important;
+  color: #312b45 !important;
+}
+
+.wps-on-boarding-wrapper .select2-results .select2-selected,
+.select2-results .select2-selected {
+  background: #f2eff8;
+  color: #5b536f;
+}
+
+.wps-on-boarding-form-btn__wrapper {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin: 28px 0 0;
+}
+
+.wps-on-boarding-form-submit,
+.wps-on-boarding-form-no_thanks {
+  display: block;
+  float: none;
+  margin: 0;
+  max-width: none !important;
+  text-align: center;
+  width: auto;
+}
+
+.wps-on-boarding-submit,
+.wps-on-boarding-no_thanks {
+  align-items: center;
+  border-radius: 16px;
+  box-shadow: none;
+  display: inline-flex;
+  font-size: 16px;
+  font-weight: 700;
+  justify-content: center;
+  letter-spacing: 0.04em;
+  min-height: 54px;
+  min-width: 172px;
+  padding: 0 26px;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.wps-on-boarding-submit {
+  background: #111 !important;
+  border: 1px solid #111 !important;
+  color: #fff !important;
+  filter: none;
+  opacity: 1;
+  width: auto;
+}
+
+.wps-on-boarding-form-verify {
+  margin: 0;
+}
+
+.wps-on-boarding-form-verify:after {
+  content: "\2192";
+  font-size: 20px;
+  right: 20px;
+  top: 16px;
+}
+
+.wps-on-boarding-no_thanks {
+  background: #111;
+  border: 1px solid #111;
+  color: #fff !important;
+}
+
+.wps-on-boarding-no_thanks:hover,
+.wps-on-boarding-submit:hover {
+  color: #fff !important;
+  opacity: 1;
+}
+
+@media only screen and (max-width: 767px) {
+  .wps-onboarding-section {
+    padding: 16px;
+  }
+
+  .wps-on-boarding-wrapper {
+    border-radius: 16px;
+    padding: 22px 18px 24px;
+  }
+
+  .wps-on-boarding-close-btn {
+    right: 16px;
+    top: 16px;
+  }
+
+  .wps-customer-data-form-single-field {
+    gap: 14px;
+    grid-template-columns: 1fr;
+    padding: 18px 0;
+  }
+
+  .wps-on-boarding-heading {
+    font-size: 22px;
+    padding-right: 40px;
+  }
+
+  .wps-on-boarding-desc {
+    font-size: 15px;
+    margin-bottom: 22px;
+  }
+
+  .wps-on-boarding-form-btn__wrapper {
+    flex-direction: column;
+  }
+
+  .wps-on-boarding-form-submit,
+  .wps-on-boarding-form-no_thanks,
+  .wps-on-boarding-submit,
+  .wps-on-boarding-no_thanks {
+    width: 100%;
+  }
+}
+
+/* Targeted onboarding popup match */
+.wps-onboarding-section {
+  backdrop-filter: none;
+  background: rgba(27, 19, 48, 0.36);
+  padding: 18px;
+}
+
+.wps-on-boarding-wrapper-background {
+  max-width: 600px;
+}
+
+.wps-on-boarding-wrapper {
+  border-radius: 10px;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.2);
+  padding: 28px 38px 34px;
+}
+
+.wps-on-boarding-close-btn {
+  border: 1px solid #e0dceb;
+  box-shadow: 0 4px 16px rgba(21, 12, 49, 0.16);
+  height: 34px;
+  right: 22px;
+  top: 22px;
+  width: 34px;
+}
+
+.wps-on-boarding-close-btn .close-form::before {
+  font-size: 22px;
+  line-height: 32px;
+}
+
+.wps-on-boarding-heading {
+  color: #2b2b2b;
+  font-size: 26px;
+  font-weight: 400;
+  line-height: 1.3;
+  margin: 8px auto 18px;
+  max-width: 100%;
+}
+
+.wps-on-boarding-desc {
+  color: #7a7a7a;
+  font-size: 16px;
+  line-height: 1.55;
+  margin: 0 auto 26px;
+  max-width: 470px;
+}
+
+.wps-customer-data-form-single-field {
+  border-top-color: #ece8f5;
+  gap: 18px;
+  grid-template-columns: 168px minmax(0, 1fr);
+  margin: 0 auto;
+  max-width: 496px;
+  padding: 22px 0;
+}
+
+.wps-customer-data-form-single-field:first-of-type {
+  align-items: start;
+  column-gap: 24px;
+  grid-template-columns: 168px minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.wps-customer-data-form-single-field:first-of-type .on-boarding-label {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  padding-top: 2px;
+}
+
+.wps-customer-data-form-single-field:first-of-type .wps-on-boarding-radio-wrapper {
+  margin: 0;
+  min-width: 0;
+}
+
+.on-boarding-label {
+  color: #231d44;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.8;
+  max-width: 168px;
+}
+
+.on-boarding-field-label {
+  color: #413a58;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.wps-on-boarding-radio-wrapper {
+  gap: 10px;
+}
+
+.wps-on-boarding-wrapper input[type="radio"] {
+  appearance: none;
+  -webkit-appearance: none;
+  background: #ffffff;
+  border: 2px solid #8e879f;
+  border-radius: 50%;
+  box-shadow: none;
+  height: 20px;
+  width: 20px;
+}
+
+.wps-on-boarding-wrapper input[type="radio"]:checked {
+  border-color: #2f2943;
+}
+
+.wps-on-boarding-wrapper input[type="radio"]:checked::before {
+  background: #2f2943;
+  border-radius: 50%;
+  content: "";
+  display: block;
+  height: 8px;
+  margin: 4px;
+  width: 8px;
+}
+
+.wps-on-boarding-wrapper input[type="text"],
+.wps-on-boarding-wrapper input[type="email"],
+.wps-on-boarding-wrapper input[type="tel"],
+.wps-on-boarding-wrapper .on-boarding-select-field,
+.wps-on-boarding-wrapper .select2-container,
+.wps-on-boarding-wrapper span.select2.select2-container.select2-container--default {
+  max-width: 296px !important;
+}
+
+.wps-on-boarding-wrapper input[type="text"],
+.wps-on-boarding-wrapper input[type="email"],
+.wps-on-boarding-wrapper input[type="tel"],
+.wps-on-boarding-wrapper .on-boarding-select-field {
+  border-radius: 14px;
+  font-size: 15px;
+  min-height: 56px;
+  padding: 14px 18px !important;
+}
+
+.wps-on-boarding-wrapper .select2-container .select2-selection--single,
+.wps-on-boarding-wrapper .select2-container .select2-selection--multiple,
+.wps-on-boarding-wrapper .select2-container-multi .select2-choices {
+  border-radius: 14px;
+  min-height: 56px;
+  padding: 10px 16px;
+}
+
+.wps-on-boarding-wrapper .select2-search-field input,
+.wps-on-boarding-wrapper input.select2-search__field {
+  color: #6f6a7d !important;
+  font-size: 15px;
+  min-width: 100%;
+  padding: 0 !important;
+  width: 100% !important;
+}
+
+.wps-on-boarding-wrapper .select2-search-choice,
+.wps-on-boarding-wrapper .select2-selection__choice {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  color: #2f2943 !important;
+  font-size: 15px !important;
+  font-weight: 500;
+  padding: 0 !important;
+}
+
+.wps-on-boarding-wrapper .select2-search-choice-close,
+.wps-on-boarding-wrapper .select2-selection__choice__remove {
+  display: none !important;
+}
+
+.wps-on-boarding-form-btn__wrapper {
+  gap: 16px;
+  margin-top: 26px;
+}
+
+.wps-on-boarding-submit,
+.wps-on-boarding-no_thanks {
+  border-radius: 16px;
+  font-size: 15px;
+  letter-spacing: 0.06em;
+  min-height: 54px;
+  min-width: 176px;
+}
+
+@media only screen and (max-width: 767px) {
+  .wps-on-boarding-wrapper-background {
+    max-width: 100%;
+  }
+
+  .wps-on-boarding-wrapper {
+    padding: 22px 18px 24px;
+  }
+
+  .wps-customer-data-form-single-field,
+  .wps-customer-data-form-single-field:first-of-type {
+    gap: 14px;
+    grid-template-columns: 1fr;
+    max-width: 100%;
+  }
+
+  .wps-customer-data-form-single-field:first-of-type .on-boarding-label {
+    grid-row: auto;
+  }
+
+  .wps-on-boarding-wrapper input[type="text"],
+  .wps-on-boarding-wrapper input[type="email"],
+  .wps-on-boarding-wrapper input[type="tel"],
+  .wps-on-boarding-wrapper .on-boarding-select-field,
+  .wps-on-boarding-wrapper .select2-container,
+  .wps-on-boarding-wrapper span.select2.select2-container.select2-container--default {
+    max-width: 100% !important;
+  }
+}

--- a/admin/js/woocommerce_gift_cards_lite-admin.js
+++ b/admin/js/woocommerce_gift_cards_lite-admin.js
@@ -68,6 +68,35 @@
 				$(this).hide();
 				$('.wps-gc__popup-for-pro').removeClass('active-pro');
 			})
+
+			$( '#wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit' ).addClass( 'wps_wgm_floating_submit' );
+			$( document ).on( 'click', '#wps_wgm_setting_wrapper .wps_wgm_dashboard_page_notice .notice-dismiss', function( e ) {
+				e.preventDefault();
+				$( this ).closest( '.wps_wgm_dashboard_page_notice' ).fadeOut( 150 );
+			} );
+
+			$( document ).on( 'click', '.wps_wgm_nav_tab_more', function( e ) {
+				e.preventDefault();
+				e.stopPropagation();
+
+				var $wrapper = $( this ).closest( '.wps_wgm_tabs_more' );
+				var isOpen = $wrapper.hasClass( 'is-open' );
+
+				$( '.wps_wgm_tabs_more' ).removeClass( 'is-open' );
+				$( '.wps_wgm_nav_tab_more' ).attr( 'aria-expanded', 'false' );
+
+				if ( ! isOpen ) {
+					$wrapper.addClass( 'is-open' );
+					$( this ).attr( 'aria-expanded', 'true' );
+				}
+			} );
+
+			$( document ).on( 'click', function( e ) {
+				if ( ! $( e.target ).closest( '.wps_wgm_tabs_more' ).length ) {
+					$( '.wps_wgm_tabs_more' ).removeClass( 'is-open' );
+					$( '.wps_wgm_nav_tab_more' ).attr( 'aria-expanded', 'false' );
+				}
+			} );
 			
 			
 			//////////////////
@@ -160,16 +189,24 @@
 				$( "#wps_wgm_mail_setting_remove_logo" ).show();
 
 			}
-			jQuery( "#wps_wgm_mail_setting" ).on( 
+			jQuery( "#wps_wgm_mail_setting" ).on(
 				'click',
-				function(){
-					jQuery( "#wps_wgm_mail_setting_wrapper" ).slideToggle();
+				function() {
+					var $mailSettingTab = jQuery( this );
+					var $mailSettingWrapper = jQuery( "#wps_wgm_mail_setting_wrapper" );
+					var isExpanded = $mailSettingTab.hasClass( 'is-open' );
+
+					$mailSettingTab.toggleClass( 'is-open', ! isExpanded );
+					$mailSettingTab.attr( 'aria-expanded', ! isExpanded ? 'true' : 'false' );
+					$mailSettingWrapper.stop( true, true ).slideToggle();
 				}
 			);
 
-			jQuery( '.wps_wgm_mail_setting_upload_logo' ).on( 
+			jQuery( 'input[type="button"].wps_wgm_mail_setting_upload_logo.button' ).on( 
 				'click',
-				function(){
+				function( e ){
+					e.preventDefault();
+					e.stopPropagation();
 					var imageurl = $( "#wps_wgm_mail_setting_upload_logo" ).val();
 					tb_show( '', 'media-upload.php?TB_iframe=true' );
 
@@ -195,10 +232,12 @@
 				}
 			);
 
-			jQuery( '.wps_wgm_mail_setting_background_logo' ).on( 
+			jQuery( 'input[type="button"].wps_wgm_mail_setting_background_logo.button' ).on( 
 				'click',
-				function()
+				function( e )
 				{
+					e.preventDefault();
+					e.stopPropagation();
 					var imageurl = $( "#wps_mail_other_setting_background_logo_value" ).val();
 					tb_show( '', 'media-upload.php?TB_iframe=true' );
 					 window.send_to_editor = function(html)

--- a/admin/partials/template_settings_function/class-woocommerce-giftcard-admin-settings.php
+++ b/admin/partials/template_settings_function/class-woocommerce-giftcard-admin-settings.php
@@ -230,14 +230,10 @@ class Woocommerce_Giftcard_Admin_Settings {
 	 * @since 2.0.0
 	 */
 	public function wps_wgm_settings_saved() {
-		?>
-		<div class="notice notice-success is-dismissible">
-			<p><strong><?php esc_html_e( 'Settings saved.', 'woo-gift-cards-lite' ); ?></strong></p>
-			<button type="button" class="notice-dismiss">
-				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss notice.', 'woo-gift-cards-lite' ); ?></span>
-			</button>
-		</div>
-		<?php
+		$GLOBALS['wps_wgm_dashboard_notice'] = array(
+			'type'    => 'success',
+			'message' => esc_html__( 'Settings saved !', 'woo-gift-cards-lite' ),
+		);
 	}
 
 	/**

--- a/admin/partials/templates/wps-wgm-delivery-setting.php
+++ b/admin/partials/templates/wps-wgm-delivery-setting.php
@@ -44,7 +44,6 @@ if ( ! is_array( $delivery_settings ) ) :
 	$delivery_settings = array();
 endif;
 ?>
-<h3 class="wps_wgm_overview_heading"><?php esc_html_e( 'Delivery Settings', 'woo-gift-cards-lite' ); ?></h3>
 <div class="wps_wgm_table_wrapper">	
 	<div class="wps_table">
 		<table class="form-table wps_wgm_general_setting">

--- a/admin/partials/templates/wps-wgm-email-template-setting.php
+++ b/admin/partials/templates/wps-wgm-email-template-setting.php
@@ -39,7 +39,6 @@ if ( $flag ) {
 }
 ?>
 <?php $mail_settings = get_option( 'wps_wgm_mail_settings', array() ); ?>
-<h3 class="wps_wgm_overview_heading"><?php esc_html_e( 'Email Settings', 'woo-gift-cards-lite' ); ?></h3>
 <div class="wps_wgm_table_wrapper">	
 	<div class="wps_table">
 		<table class="form-table wps_wgm_general_setting">
@@ -51,7 +50,10 @@ if ( $flag ) {
 		</table>
 	</div>
 </div>
-<h3 id="wps_wgm_mail_setting" class="wps_wgm_mail_setting_tab"><?php esc_html_e( 'Mail Settings', 'woo-gift-cards-lite' ); ?></h3>
+<h3 id="wps_wgm_mail_setting" class="wps_wgm_mail_setting_tab" aria-expanded="false">
+	<span class="wps_wgm_mail_setting_tab_label"><?php esc_html_e( 'Mail Settings', 'woo-gift-cards-lite' ); ?></span>
+	<span class="wps_wgm_mail_setting_toggle" aria-hidden="true"></span>
+</h3>
 <div id="wps_wgm_mail_setting_wrapper" class="wps_wgm_table_wrapper">
 	<table class="form-table wps_wgm_general_setting">	
 		<tbody>

--- a/admin/partials/templates/wps-wgm-general-setting.php
+++ b/admin/partials/templates/wps-wgm-general-setting.php
@@ -47,8 +47,7 @@ if ( $flag ) {
 }
 ?>
 <?php $general_settings = get_option( 'wps_wgm_general_settings', array() ); ?>
-<h3 class="wps_wgm_overview_heading"><?php esc_html_e( 'General Settings', 'woo-gift-cards-lite' ); ?></h3>
-<div class="wps_wgm_table_wrapper">	
+	<div class="wps_wgm_table_wrapper">	
 	<div class="wps_table">
 		<table class="form-table wps_wgm_general_setting">
 			<tbody>

--- a/admin/partials/templates/wps-wgm-other-setting.php
+++ b/admin/partials/templates/wps-wgm-other-setting.php
@@ -38,7 +38,6 @@ if ( $flag ) {
 }
 ?>
 <?php $other_settings = get_option( 'wps_wgm_other_settings', array() ); ?>
-<h3 class="wps_wgm_overview_heading"><?php esc_html_e( 'Other Settings', 'woo-gift-cards-lite' ); ?></h3>
 <div class="wps_wgm_table_wrapper">	
 	<div class="wps_table">
 		<div style="display: none;" class="loading-style-bg" id="wps_wgm_loader_other">

--- a/admin/partials/templates/wps-wgm-overview-setting.php
+++ b/admin/partials/templates/wps-wgm-overview-setting.php
@@ -12,32 +12,78 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div class="wps_wgm_table_wrapper wps_wgm_overview-wrapper">
-	
-	<div class="wps_wgm_overview_content">
-	 
-		<h3 class="wps_wgm_overview_heading">
-			<?php esc_html_e( 'Connect With Us and Explore More About Ultimate Gift Cards For WooCommerce', 'woo-gift-cards-lite' ); ?>
-		</h3>
-		
-		<p><?php esc_html_e( 'Ultimate Gift Cards For WooCommerce is the plugin that allows merchants (admin) to manage store with digital gifting solutions like this. Here the merchant can create gifts cards according to his desires and wishes after selection of the price selection. This digital certificate e-solution comes with ample number benefits like capable to increase sales, encourage an easy and desire gifting solution for your customers, initiate e-gifting via emails. ', 'woo-gift-cards-lite' ); ?>
-		</p>
-	</div>
 	<?php
-	if ( ! wps_uwgc_pro_active() ) {
-		?>
-		<div class="wps_wgm_video_wrapper">
-			<iframe height="411" src="https://www.youtube.com/embed/g6JLA3ewph8?si=mzCftUBqh8AJFit2" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-		</div>
-		<?php
-	} else {
-		?>
-		<div class="wps_wgm_video_wrapper">
-			<iframe height="411" src="https://www.youtube.com/embed/zxMqtV-HJLQ?si=WhZtX5-JCFCEG2fT" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-		</div>
-		<?php
-	}
+	$wgm_support_link = 'https://wpswings.com/submit-query/?utm_source=wpswings-giftcards-support&utm_medium=giftcards-org-backend&utm_campaign=support';
+	$wgm_overview_cards = array(
+		array(
+			'image'       => WPS_WGC_URL . 'assets/images/featur1.png',
+			'image_alt'   => __( 'Gift card templates', 'woo-gift-cards-lite' ),
+			'title'       => __( 'Flexible gift card templates', 'woo-gift-cards-lite' ),
+			'description' => __( 'Launch branded gifting faster with editable templates, custom messaging, and product-ready gift card designs.', 'woo-gift-cards-lite' ),
+		),
+		array(
+			'image'       => WPS_WGC_URL . 'assets/images/wps-feature2.png',
+			'image_alt'   => __( 'Redeem and recharge gift cards', 'woo-gift-cards-lite' ),
+			'title'       => __( 'Redeem and recharge flows', 'woo-gift-cards-lite' ),
+			'description' => __( 'Let shoppers redeem balances with confidence and support reload-ready gift card workflows from one plugin.', 'woo-gift-cards-lite' ),
+		),
+		array(
+			'image'       => WPS_WGC_URL . 'assets/images/featur3.png',
+			'image_alt'   => __( 'QR code and barcode security', 'woo-gift-cards-lite' ),
+			'title'       => __( 'Secure coupon delivery', 'woo-gift-cards-lite' ),
+			'description' => __( 'Strengthen digital gifting with QR and barcode support for easier validation and safer coupon sharing.', 'woo-gift-cards-lite' ),
+		),
+		array(
+			'image'       => WPS_WGC_URL . 'assets/images/featur6.png',
+			'image_alt'   => __( 'Scheduled gift cards', 'woo-gift-cards-lite' ),
+			'title'       => __( 'Scheduled gifting', 'woo-gift-cards-lite' ),
+			'description' => __( 'Deliver gift cards on birthdays, holidays, or campaign launch dates with scheduled email-based delivery.', 'woo-gift-cards-lite' ),
+		),
+		array(
+			'image'       => WPS_WGC_URL . 'assets/images/featur5.png',
+			'image_alt'   => __( 'Gift card reporting', 'woo-gift-cards-lite' ),
+			'title'       => __( 'Reporting and performance', 'woo-gift-cards-lite' ),
+			'description' => __( 'Track gifting activity, coupon usage, and store-level performance to understand how gift cards drive revenue.', 'woo-gift-cards-lite' ),
+		),
+	);
+	?>
 
+	<div class="wps-wgm-overview">
+		<div class="wps-wgm-overview__hero">
+			<div class="wps-wgm-overview__icon"><?php esc_html_e( 'GC', 'woo-gift-cards-lite' ); ?></div>
+			<span class="wps-wgm-overview__eyebrow"><?php esc_html_e( 'Overview', 'woo-gift-cards-lite' ); ?></span>
+			<h2><?php esc_html_e( 'Digital gifting workflows built for WooCommerce stores', 'woo-gift-cards-lite' ); ?></h2>
+			<p><?php esc_html_e( 'Ultimate Gift Cards for WooCommerce helps merchants launch branded gift cards, automate delivery, manage redemption, and build repeat-purchase flows through flexible gifting experiences.', 'woo-gift-cards-lite' ); ?></p>
+		</div>
 
+		<div class="wps-wgm-overview__heading-row">
+			<span><?php esc_html_e( 'Top features of this plugin', 'woo-gift-cards-lite' ); ?></span>
+		</div>
+
+		<div class="wps-wgm-overview__grid">
+			<?php foreach ( $wgm_overview_cards as $wgm_overview_card ) : ?>
+				<div class="wps-wgm-overview-card">
+					<div class="wps-wgm-overview-card__media">
+						<img src="<?php echo esc_url( $wgm_overview_card['image'] ); ?>" alt="<?php echo esc_attr( $wgm_overview_card['image_alt'] ); ?>">
+					</div>
+					<h3><?php echo esc_html( $wgm_overview_card['title'] ); ?></h3>
+					<p><?php echo esc_html( $wgm_overview_card['description'] ); ?></p>
+				</div>
+			<?php endforeach; ?>
+		</div>
+
+		<div class="wps-wgm-overview__cta">
+			<div>
+				<strong><?php esc_html_e( 'Need help with gifting setup?', 'woo-gift-cards-lite' ); ?></strong>
+				<p><?php esc_html_e( 'Reach out for support with gift card configuration, delivery setup, and advanced gifting workflows for your store.', 'woo-gift-cards-lite' ); ?></p>
+			</div>
+			<div class="wps-wgm-overview__cta-actions">
+				<a href="<?php echo esc_url( $wgm_support_link ); ?>" target="_blank" class="wps-wgm-overview__button wps-wgm-overview__button--secondary"><?php esc_html_e( 'Contact Support', 'woo-gift-cards-lite' ); ?></a>
+			</div>
+		</div>
+	</div>
+
+	<?php
 	if ( ! is_plugin_active( 'giftware/giftware.php' ) ) {
 
 
@@ -368,6 +414,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 
-</div>
 		<?php
 	}
+	?>
+</div>

--- a/admin/partials/templates/wps-wgm-product-setting.php
+++ b/admin/partials/templates/wps-wgm-product-setting.php
@@ -63,7 +63,6 @@ if ( $flag ) {
 }
 ?>
 <?php $product_settings = get_option( 'wps_wgm_product_settings', array() ); ?>
-<h3 class="wps_wgm_overview_heading"><?php esc_html_e( 'Product Settings', 'woo-gift-cards-lite' ); ?></h3>
 <div class="wps_wgm_table_wrapper">
     <table class="form-table wps_wgm_product_setting">
         <tbody>

--- a/admin/partials/woocommerce-gift-cards-lite-admin-display.php
+++ b/admin/partials/woocommerce-gift-cards-lite-admin-display.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Provide a admin area view for the plugin
+ * Provide a admin area view for the plugin.
  *
  * This file is used to markup the admin-facing aspects of the plugin.
  *
@@ -15,314 +15,375 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
 if ( class_exists( 'Makewebbetter_Onboarding_Helper' ) ) {
-
 	$this->onboard = new Makewebbetter_Onboarding_Helper();
-
 }
-/*  create the settings tabs*/
+
+$is_pro_active = wps_uwgc_pro_active();
+
 $wps_wgm_setting_tab = array(
 	'overview_setting' => array(
-		'title' => esc_html__( 'OverView', 'woo-gift-cards-lite' ),
+		'title'     => esc_html__( 'Overview', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-overview-setting.php',
 	),
-	'general_setting' => array(
-		'title' => esc_html__( 'General', 'woo-gift-cards-lite' ),
+	'general_setting'  => array(
+		'title'     => esc_html__( 'General', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-general-setting.php',
 	),
-	'product_setting' => array(
-		'title' => esc_html__( 'Product', 'woo-gift-cards-lite' ),
+	'product_setting'  => array(
+		'title'     => esc_html__( 'Product', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-product-setting.php',
 	),
-	'email_setting' => array(
-		'title' => esc_html__( 'Email Template', 'woo-gift-cards-lite' ),
+	'email_setting'    => array(
+		'title'     => esc_html__( 'Email Template', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-email-template-setting.php',
 	),
-	'delivery_method' => array(
-		'title' => esc_html__( 'Delivery Method', 'woo-gift-cards-lite' ),
+	'delivery_method'  => array(
+		'title'     => esc_html__( 'Delivery Method', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-delivery-setting.php',
 	),
-	'other_setting' => array(
-		'title' => esc_html__( 'Other Settings', 'woo-gift-cards-lite' ),
+	'other_setting'    => array(
+		'title'     => esc_html__( 'Other Settings', 'woo-gift-cards-lite' ),
 		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-other-setting.php',
 	),
 );
-if ( ! wps_uwgc_pro_active() ) {
-	$wps_wgm_setting_tab = array(
-		'overview_setting' => array(
-			'title' => esc_html__( 'OverView', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-overview-setting.php',
-		),
-		'general_setting' => array(
-			'title' => esc_html__( 'General', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-general-setting.php',
-		),
-		'product_setting' => array(
-			'title' => esc_html__( 'Product', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-product-setting.php',
-		),
-		'email_setting' => array(
-			'title' => esc_html__( 'Email Template', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-email-template-setting.php',
-		),
-		'delivery_method' => array(
-			'title' => esc_html__( 'Delivery Method', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-delivery-setting.php',
-		),
-		'other_setting' => array(
-			'title' => esc_html__( 'Other Settings', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-other-setting.php',
-		),
-		'offline_setting' => array(
-			'title' => esc_html__( 'Offline Giftcards', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-offline-setting.php',
-		),
-		'import_export_setting' => array(
-			'title' => esc_html__( 'Import/ Export', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-im-export-setting.php',
-		),
-		'group_gifting_setting' => array(
-			'title' => esc_html__( 'Group Gifting', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-group-gifting-setting.php',
-		),
-		'discount_setting' => array(
-			'title' => esc_html__( 'Discount', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-discount-setting.php',
-		),
-		'thankyou_setting' => array(
-			'title' => esc_html__( 'Thankyou order', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-thankyou-setting.php',
-		),
-		'qrcode_setting' => array(
-			'title' => esc_html__( 'Qrcode / Barcode', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-qrcode-setting.php',
-		),
-		'customizable_setting' => array(
-			'title' => esc_html__( 'Customizable Giftcard', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-customizable-setting.php',
-		),
-		'notification_setting' => array(
-			'title' => esc_html__( 'Notification', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-notification-setting.php',
-		),
-		'rest_api_setting' => array(
-			'title' => esc_html__( 'REST API', 'woo-gift-cards-lite' ),
-			'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-rest-api-setting.php',
-		),
+
+if ( ! $is_pro_active ) {
+	$wps_wgm_setting_tab['offline_setting'] = array(
+		'title'     => esc_html__( 'Offline Giftcards', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-offline-setting.php',
+	);
+	$wps_wgm_setting_tab['import_export_setting'] = array(
+		'title'     => esc_html__( 'Import/ Export', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-im-export-setting.php',
+	);
+	$wps_wgm_setting_tab['group_gifting_setting'] = array(
+		'title'     => esc_html__( 'Group Gifting', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-group-gifting-setting.php',
+	);
+	$wps_wgm_setting_tab['discount_setting'] = array(
+		'title'     => esc_html__( 'Discount', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-discount-setting.php',
+	);
+	$wps_wgm_setting_tab['thankyou_setting'] = array(
+		'title'     => esc_html__( 'Thankyou order', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-thankyou-setting.php',
+	);
+	$wps_wgm_setting_tab['qrcode_setting'] = array(
+		'title'     => esc_html__( 'Qrcode / Barcode', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-qrcode-setting.php',
+	);
+	$wps_wgm_setting_tab['customizable_setting'] = array(
+		'title'     => esc_html__( 'Customizable Giftcard', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-customizable-setting.php',
+	);
+	$wps_wgm_setting_tab['notification_setting'] = array(
+		'title'     => esc_html__( 'Notification', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-notification-setting.php',
+	);
+	$wps_wgm_setting_tab['rest_api_setting'] = array(
+		'title'     => esc_html__( 'REST API', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-rest-api-setting.php',
 	);
 }
 ?>
 <div class="wps-gc__popup-for-pro-wrap">
-	<div class="wps-gc__popup-for-pro-shadow">
-
-	</div>
+	<div class="wps-gc__popup-for-pro-shadow"></div>
 	<div class="wps-gc__popup-for-pro">
 		<span class="wps-gc__popup-for-pro-close">+</span>
-		<h2 class="wps-gc__popup-for-pro-title">Unlock More Features with Pro Upgrade! </h2>
-		<p class="wps-gc__popup-for-pro-content">Congratulations on discovering our premium Features! This stunning
-			features is reserved for our Pro members, offering you a world of creative possibilities. Upgrade today to
-			unlock it and access a wealth of exclusive features.</p>
+		<h2 class="wps-gc__popup-for-pro-title"><?php esc_html_e( 'Unlock More Features with Pro Upgrade!', 'woo-gift-cards-lite' ); ?></h2>
+		<p class="wps-gc__popup-for-pro-content"><?php esc_html_e( 'Congratulations on discovering our premium Features! This stunning features is reserved for our Pro members, offering you a world of creative possibilities. Upgrade today to unlock it and access a wealth of exclusive features.', 'woo-gift-cards-lite' ); ?></p>
 		<div class="wps-gc__popup-for-pro-link-wrap">
-			<a target="_blank"
+			<a
+				class="wps-gc__popup-for-pro-link"
 				href="https://wpswings.com/product/gift-cards-for-woocommerce-pro/?utm_source=wpswings-giftcards-pro&utm_medium=giftcards-org-backend&utm_campaign=go-pro"
-				class="wps-gc__popup-for-pro-link">Go pro now</a>
+				target="_blank"
+			><?php esc_html_e( 'Go pro now', 'woo-gift-cards-lite' ); ?></a>
 		</div>
 	</div>
 </div>
 <?php
-			$wps_wgm_setting_tab = apply_filters( 'wps_wgm_add_gift_card_setting_tab_before', $wps_wgm_setting_tab );
-			$wps_wgm_setting_tab['redeem_tab'] = array(
-				'title' => esc_html__( 'Gift Card Redeem', 'woo-gift-cards-lite' ),
-				'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/redeem-giftcard-settings.php',
+$wps_wgm_setting_tab = apply_filters( 'wps_wgm_add_gift_card_setting_tab_before', $wps_wgm_setting_tab );
+$wps_wgm_setting_tab['redeem_tab'] = array(
+	'title'     => esc_html__( 'Gift Card Redeem', 'woo-gift-cards-lite' ),
+	'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/redeem-giftcard-settings.php',
+);
+
+if ( ! $is_pro_active ) {
+	$wps_wgm_setting_tab['premium_plugin'] = array(
+		'title'     => esc_html__( 'Premium Features', 'woo-gift-cards-lite' ),
+		'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-premium-features.php',
+	);
+}
+
+$wps_wgm_setting_tab = apply_filters( 'wps_wgm_add_gift_card_setting_tab_after', $wps_wgm_setting_tab );
+
+$lite_visible_tabs = array(
+	'overview_setting',
+	'general_setting',
+	'product_setting',
+	'email_setting',
+	'delivery_method',
+	'other_setting',
+	'redeem_tab',
+	'premium_plugin',
+);
+
+$visible_setting_tabs = $wps_wgm_setting_tab;
+
+$default_tab = 'overview_setting';
+$requested_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : $default_tab;
+$active_tab = array_key_exists( $requested_tab, $visible_setting_tabs ) ? $requested_tab : $default_tab;
+$active_tab_data = isset( $visible_setting_tabs[ $active_tab ] ) ? $visible_setting_tabs[ $active_tab ] : array();
+$active_tab_title = isset( $active_tab_data['title'] ) ? $active_tab_data['title'] : esc_html__( 'Gift Card Settings', 'woo-gift-cards-lite' );
+$tab_descriptions = array(
+	'overview_setting'      => esc_html__( 'Review plugin activity, shortcuts, and essential setup details for your store.', 'woo-gift-cards-lite' ),
+	'general_setting'       => esc_html__( 'Control the base plugin behavior, delivery rules, and request availability windows.', 'woo-gift-cards-lite' ),
+	'product_setting'       => esc_html__( 'Manage gift card product rules, field visibility, pricing, and purchase configuration.', 'woo-gift-cards-lite' ),
+	'email_setting'         => esc_html__( 'Configure email templates, sender details, and delivery messages for gift cards.', 'woo-gift-cards-lite' ),
+	'delivery_method'       => esc_html__( 'Control how gift cards are sent, scheduled, and delivered to recipients.', 'woo-gift-cards-lite' ),
+	'other_setting'         => esc_html__( 'Manage additional gift card behavior, restrictions, and supporting options.', 'woo-gift-cards-lite' ),
+	'offline_setting'       => esc_html__( 'Manage offline gift card workflows, imports, and delivery handling.', 'woo-gift-cards-lite' ),
+	'import_export_setting' => esc_html__( 'Import or export gift card data, templates, and bulk configuration records.', 'woo-gift-cards-lite' ),
+	'group_gifting_setting' => esc_html__( 'Configure collaborative gifting flows and related purchase controls.', 'woo-gift-cards-lite' ),
+	'discount_setting'      => esc_html__( 'Manage discount-related gift card options and reward settings.', 'woo-gift-cards-lite' ),
+	'thankyou_setting'      => esc_html__( 'Customize thank you order workflows and post-purchase gift card messaging.', 'woo-gift-cards-lite' ),
+	'qrcode_setting'        => esc_html__( 'Configure QR and barcode behavior for scanning and redemption workflows.', 'woo-gift-cards-lite' ),
+	'customizable_setting'  => esc_html__( 'Manage customer-facing customization choices for gift card presentation.', 'woo-gift-cards-lite' ),
+	'notification_setting'  => esc_html__( 'Manage reminder, expiry, and event-based notification settings.', 'woo-gift-cards-lite' ),
+	'rest_api_setting'      => esc_html__( 'Configure REST API access and gift card integration settings.', 'woo-gift-cards-lite' ),
+	'redeem_tab'            => esc_html__( 'Control redeem, recharge, and balance workflows from one place.', 'woo-gift-cards-lite' ),
+	'premium_plugin'        => esc_html__( 'Explore premium-only modules available for advanced gift card workflows.', 'woo-gift-cards-lite' ),
+);
+$active_tab_description = isset( $tab_descriptions[ $active_tab ] ) ? $tab_descriptions[ $active_tab ] : esc_html__( 'Configure and manage all gift card options from this section.', 'woo-gift-cards-lite' );
+$plugin_display_version = defined( 'WPS_WGC_VERSION' ) ? WPS_WGC_VERSION : '3.2.7';
+if ( $is_pro_active && defined( 'WPS_UWGC_PLUGIN_VERSION' ) ) {
+	$plugin_display_version = WPS_UWGC_PLUGIN_VERSION;
+}
+$plugin_version_label = sprintf(
+	/* translators: 1: plugin version, 2: edition label */
+	esc_html__( 'v%1$s %2$s', 'woo-gift-cards-lite' ),
+	$plugin_display_version,
+	$is_pro_active ? esc_html__( 'Pro', 'woo-gift-cards-lite' ) : esc_html__( 'Lite', 'woo-gift-cards-lite' )
+);
+
+$max_primary_tabs = 8;
+$primary_setting_tabs = array_slice( $visible_setting_tabs, 0, $max_primary_tabs, true );
+$overflow_setting_tabs = array_slice( $visible_setting_tabs, $max_primary_tabs, null, true );
+$is_overflow_active = array_key_exists( $active_tab, $overflow_setting_tabs );
+
+$help_links = array(
+	array(
+		'label' => esc_html__( 'Watch Video', 'woo-gift-cards-lite' ),
+		'url'   => 'https://www.youtube.com/watch?v=g6JLA3ewph8',
+	),
+	array(
+		'label' => esc_html__( 'Documentation', 'woo-gift-cards-lite' ),
+		'url'   => $is_pro_active
+			? 'https://docs.wpswings.com/gift-cards-for-woocommerce/?utm_source=wpswings-giftcards-doc&utm_medium=giftcards-pro-backend&utm_campaign=documentation'
+			: 'https://docs.wpswings.com/woo-gift-cards-lite/?utm_source=wpswings-giftcards-doc&utm_medium=giftcards-org-backend&utm_campaign=documentation',
+	),
+	array(
+		'label' => esc_html__( 'Contact Us', 'woo-gift-cards-lite' ),
+		'url'   => $is_pro_active
+			? 'https://wpswings.com/contact-us/?utm_source=wpswings-giftcards-contact&utm_medium=giftcards-pro-backend&utm_campaign=giftcards-contact'
+			: 'https://wpswings.com/contact-us/?utm_source=wpswings-giftcards-contact&utm_medium=giftcards-org-backend&utm_campaign=contact',
+	),
+	array(
+		'label' => esc_html__( 'Explore More Plugins', 'woo-gift-cards-lite' ),
+		'url'   => 'https://wpswings.com/woocommerce-plugins/?utm_source=wpswings-giftcards-shop&utm_medium=giftcards-org-backend&utm_campaign=shop-page',
+	),
+);
+
+$secure_nonce = wp_create_nonce( 'wps-gc-auth-nonce' );
+$id_nonce_verified = wp_verify_nonce( $secure_nonce, 'wps-gc-auth-nonce' );
+if ( ! $id_nonce_verified ) {
+	wp_die( esc_html__( 'Nonce Not verified', 'woo-gift-cards-lite' ) );
+}
+
+$dashboard_top_notice = array();
+if (
+	'POST' === strtoupper( isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '' ) &&
+	isset( $_REQUEST['wps-wgc-nonce'] ) &&
+	wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['wps-wgc-nonce'] ) ), 'wps-wgc-nonce' )
+) {
+	$posted_keys = array_keys( wp_unslash( $_POST ) );
+	foreach ( $posted_keys as $posted_key ) {
+		if ( preg_match( '/^(wps_wgm_save_|wps_uwgc_save_|wps_uwgc_generate_api_key$)/', $posted_key ) ) {
+			$dashboard_top_notice = array(
+				'type'    => 'success',
+				'message' => esc_html__( 'Settings saved !', 'woo-gift-cards-lite' ),
 			);
-			if ( ! wps_uwgc_pro_active() ) {
-				$wps_wgm_setting_tab['premium_plugin'] = array(
-					'title' => esc_html__( 'Premium Features', 'woo-gift-cards-lite' ),
-					'file_path' => WPS_WGC_DIRPATH . 'admin/partials/templates/wps-wgm-premium-features.php',
-				);
-			}
-			$wps_wgm_setting_tab = apply_filters( 'wps_wgm_add_gift_card_setting_tab_after', $wps_wgm_setting_tab );
-			do_action( 'wps_uwgc_show_notice' );
-			?>
-<div class="wrap woocommerce" id="wps_wgm_setting_wrapper">
-	<input type="hidden" class="treat-button">
-	<div style="display: none;" class="loading-style-bg" id="wps_wgm_loader">
-		<img src="<?php echo esc_url( WPS_WGC_URL . 'assets/images/loading.gif' ); ?>">
-	</div>
-	<form enctype="multipart/form-data" action="" id="mainform" method="post">
-		<div class="wps_wgm_header">
-			<div class="wps_wgm_header_content_left">
-				<div>
-					<h3 class="wps_wgm_setting_title">
-						<?php esc_html_e( 'Gift Card Settings', 'woo-gift-cards-lite' ); ?></h3>
-				</div>
-			</div>
-			<div class="wps_wgm_header_content_right">
-				<ul>
-					<?php
-					if ( wps_uwgc_pro_active() ) {
-						?>
-					<li class="wps_wgm_header_menu_button"><a
-							href="https://wpswings.com/contact-us/?utm_source=wpswings-giftcards-contact&utm_medium=giftcards-pro-backend&utm_campaign=giftcards-contact"
-							target="_blank">
-							<span class="dashicons dashicons-phone"></span>
-							<span
-								class="wps-wgn-icon-text"><?php esc_html_e( 'CONTACT US', 'woo-gift-cards-lite' ); ?></span>
-						</a>
-					</li>
-					<li class="wps_wgm_header_menu_button"><a
-							href="https://docs.wpswings.com/gift-cards-for-woocommerce/?utm_source=wpswings-giftcards-doc&utm_medium=giftcards-pro-backend&utm_campaign=documentation"
-							target="_blank">
-							<span class="dashicons dashicons-media-document"></span>
-							<span class="wps-wgn-icon-text"><?php esc_html_e( 'DOC', 'woo-gift-cards-lite' ); ?></span>
-						</a>
-					</li>
-						<?php
-					} else {
-						?>
-					<li class="wps_wgm_header_menu_button"><a
-							href="https://wpswings.com/contact-us/?utm_source=wpswings-giftcards-contact&utm_medium=giftcards-org-backend&utm_campaign=contact"
-							target="_blank">
-							<span class="dashicons dashicons-phone"></span>
-							<span
-								class="wps-wgn-icon-text"><?php esc_html_e( 'CONTACT US', 'woo-gift-cards-lite' ); ?></span>
-						</a>
-					</li>
-					<li class="wps_wgm_header_menu_button"><a
-							href="https://docs.wpswings.com/woo-gift-cards-lite/?utm_source=wpswings-giftcards-doc&utm_medium=giftcards-org-backend&utm_campaign=documentation"
-							target="_blank">
-							<span class="dashicons dashicons-media-document"></span>
-							<span class="wps-wgn-icon-text"><?php esc_html_e( 'DOC', 'woo-gift-cards-lite' ); ?></span>
-						</a>
-					</li>
-					<li class="wps_wgm_header_menu_button wps-gc-demo-image"><a
-							href="https://demo.wpswings.com/gift-cards-for-woocommerce-pro/?utm_source=wpswings-giftcards-demo&utm_medium=giftcards-org-backend&utm_campaign=demo"
-							class="wps-wgn-icon-text" title="" target="_blank">
-							<img src="<?php echo esc_url( WPS_WGC_URL ); ?>assets/images/Demo.svg" class="wps-info-img"
-								alt="Demo image">
-							<span class="wps-wgn-icon-text"><?php esc_html_e( 'DEMO', 'woo-gift-cards-lite' ); ?></span>
-						</a>
-					</li>
-					<li class="wps_wgm_header_menu_button">
-						<a href="https://wpswings.com/product/gift-cards-for-woocommerce-pro/?utm_source=wpswings-giftcards-pro&utm_medium=giftcards-org-backend&utm_campaign=go-pro"
-							class="wps-wgn-icon-text" title=""
-							target="_blank"><?php esc_html_e( 'GO PRO NOW', 'woo-gift-cards-lite' ); ?></a>
-					</li>
-
-						<?php
-					}
-					?>
-				</ul>
-			</div>
-		</div>
-		<?php
-		$secure_nonce      = wp_create_nonce( 'wps-gc-auth-nonce' );
-		$id_nonce_verified = wp_verify_nonce( $secure_nonce, 'wps-gc-auth-nonce' );
-		if ( ! $id_nonce_verified ) {
-				wp_die( esc_html__( 'Nonce Not verified', 'woo-gift-cards-lite' ) );
+			break;
 		}
-		wp_nonce_field( 'wps-wgc-nonce', 'wps-wgc-nonce' );
+		if ( preg_match( '/reset_save$/', $posted_key ) ) {
+			$dashboard_top_notice = array(
+				'type'    => 'success',
+				'message' => esc_html__( 'Settings saved !', 'woo-gift-cards-lite' ),
+			);
+			break;
+		}
+	}
+}
 
-		?>
-		<div class="wps_wgm_main_template">
-			<div class="wps_wgm_body_template">
-				<div class="wps_wgm_mobile_nav">
-					<span class="dashicons dashicons-menu"></span>
-				</div>
-				<div class="wps_wgm_navigator_template">
-					<div class="wps_wgm-navigations">
-						<?php
+$dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboard_top_notice, $active_tab );
+?>
+<div class="wrap woocommerce" id="wps_wgm_setting_wrapper">
+	<input class="treat-button" type="hidden">
+	<div class="loading-style-bg" id="wps_wgm_loader" style="display: none;">
+		<img alt="<?php esc_attr_e( 'Loading', 'woo-gift-cards-lite' ); ?>" src="<?php echo esc_url( WPS_WGC_URL . 'assets/images/loading.gif' ); ?>">
+	</div>
+	<form action="" enctype="multipart/form-data" id="mainform" method="post">
+		<?php wp_nonce_field( 'wps-wgc-nonce', 'wps-wgc-nonce' ); ?>
 
-						if ( isset( $wps_wgm_setting_tab ) && ! empty( $wps_wgm_setting_tab ) && is_array( $wps_wgm_setting_tab ) ) {
-							foreach ( $wps_wgm_setting_tab as $key => $wps_tab ) {
+		<div class="wps_wgm_dashboard_shell">
 
-								if ( isset( $_GET['tab'] ) && sanitize_key( wp_unslash( $_GET['tab'] ) ) == $key ) {
-
-									if ( 'premium_plugin' !== $key && 'redeem_tab' !== $key && 'overview_setting' !== $key && 'general_setting' !== $key && 'product_setting' !== $key && 'product_setting' !== $key && 'email_setting' !== $key && 'delivery_method' !== $key && 'other_setting' !== $key ) {
-
-										?>
-						<div class="wps_wgm_tabs">
-							<a class="wps_wgm_nav_tab nav-tab nav-tab-active wps-gift-cards-pro-tag"
-								href="?post_type=giftcard&page=wps-wgc-setting-lite&tab=<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $wps_tab['title'] ); ?>
-										<?php if ( ! wps_uwgc_pro_active() ) { ?>
-								<span><?php esc_html_e( 'Pro', 'woo-gift-cards-lite' ); ?></span>
-							<?php } ?>
-								</a>
-						</div>
-										<?php
-									} else {
-
-										?>
-
-						<div class="wps_wgm_tabs">
-							<a class="wps_wgm_nav_tab nav-tab nav-tab-active"
-								href="?post_type=giftcard&page=wps-wgc-setting-lite&tab=<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $wps_tab['title'] ); ?></a>
-						</div>
-										<?php
-									}
-								} else {
-									if ( ! isset( $_GET['tab'] ) && 'overview_setting' == $key ) {
-										?>
-						<div class="wps_wgm_tabs">
-							<a class="wps_wgm_nav_tab nav-tab nav-tab-active"
-								href="?post_type=giftcard&page=wps-wgc-setting-lite&tab=<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $wps_tab['title'] ); ?></a>
-						</div>
-										<?php
-									} else {
-
-										if ( 'premium_plugin' !== $key && 'redeem_tab' !== $key && 'overview_setting' !== $key && 'general_setting' !== $key && 'product_setting' !== $key && 'product_setting' !== $key && 'email_setting' !== $key && 'delivery_method' !== $key && 'other_setting' !== $key ) {
-
-											?>
-						<div class="wps_wgm_tabs">
-							<a class="wps_wgm_nav_tab nav-tab wps-gift-cards-pro-tag"
-								href="?post_type=giftcard&page=wps-wgc-setting-lite&tab=<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $wps_tab['title'] ); ?>
-											<?php if ( ! wps_uwgc_pro_active() ) { ?>
-								<span><?php esc_html_e( 'Pro', 'woo-gift-cards-lite' ); ?></span>
-							<?php } ?>
-							</a>
-						</div>
-											<?php
-										} else {
-
-											?>
-
-						<div class="wps_wgm_tabs">
-							<a class="wps_wgm_nav_tab nav-tab"
-								href="?post_type=giftcard&page=wps-wgc-setting-lite&tab=<?php echo esc_attr( $key ); ?>"><?php echo esc_attr( $wps_tab['title'] ); ?></a>
-						</div>
-											<?php
-										}
-									}
-								}
-							}
-						}
-						?>
-
+			<div class="wps_wgm_dashboard_notice_stack">
+				<div class="wps_wgm_dashboard_notice wps_wgm_dashboard_notice_status">
+					<div class="wps_wgm_dashboard_notice_badge wps_wgm_dashboard_notice_badge_dark">
+						<?php echo esc_html( $is_pro_active ? __( 'PRO ACTIVE', 'woo-gift-cards-lite' ) : __( 'FREE ACTIVE', 'woo-gift-cards-lite' ) ); ?>
+					</div>
+					<div class="wps_wgm_dashboard_notice_copy">
+						<strong><?php echo esc_html( $is_pro_active ? __( 'Gift Cards for WooCommerce Pro', 'woo-gift-cards-lite' ) : __( 'Gift Card Settings Dashboard', 'woo-gift-cards-lite' ) ); ?></strong>
+					</div>
+					<div class="wps_wgm_dashboard_notice_meta">
+						<?php echo esc_html( $is_pro_active ? $plugin_version_label : __( 'Lite', 'woo-gift-cards-lite' ) ); ?>
 					</div>
 				</div>
-				<?php
-				if ( isset( $wps_wgm_setting_tab ) && ! empty( $wps_wgm_setting_tab ) && is_array( $wps_wgm_setting_tab ) ) {
-					foreach ( $wps_wgm_setting_tab as $key => $wps_file ) {
-						if ( isset( $_GET['tab'] ) && sanitize_key( wp_unslash( $_GET['tab'] ) ) == $key ) {
-							$include_tab = isset( $wps_file['file_path'] ) ? $wps_file['file_path'] : '';
-							?>
-				<div class="wps_wgm_content_template">
-							<?php include_once $include_tab; ?>
-				</div>
-							<?php
-						} elseif ( ! isset( $_GET['tab'] ) && 'overview_setting' == $key ) {
-							$include_tab = isset( $wps_file['file_path'] ) ? $wps_file['file_path'] : '';
-							?>
-				<div class="wps_wgm_content_template">
-							<?php include_once $include_tab; ?>
-				</div>
-							<?php
-							break;
+			</div>
+
+			<div class="wps_wgm_dashboard_notice_row">
+				<?php do_action( 'wps_uwgc_show_notice' ); ?>
+			</div>
+
+			<div class="wps_wgm_main_template">
+				<div class="wps_wgm_dashboard_tabs" role="tablist" aria-label="<?php esc_attr_e( 'Gift card settings tabs', 'woo-gift-cards-lite' ); ?>">
+					<div class="wps_wgm_tabs_meta">
+						<span class="wps_wgm_tabs_version"><?php echo esc_html( $plugin_version_label ); ?></span>
+					</div>
+					<?php foreach ( $primary_setting_tabs as $key => $wps_tab ) : ?>
+						<?php
+						$is_active = ( $active_tab === $key );
+						$is_locked = ( ! $is_pro_active && ! in_array( $key, $lite_visible_tabs, true ) );
+						$tab_classes = array( 'wps_wgm_nav_tab', 'nav-tab' );
+
+						if ( $is_active ) {
+							$tab_classes[] = 'nav-tab-active';
 						}
-					}
-				}
-				?>
+						if ( $is_locked ) {
+							$tab_classes[] = 'wps-gift-cards-pro-tag';
+							$tab_classes[] = 'wps_wgm_nav_tab_locked';
+						}
+						?>
+							<div class="wps_wgm_tabs">
+								<a
+									class="<?php echo esc_attr( implode( ' ', $tab_classes ) ); ?>"
+									data-locked="<?php echo esc_attr( $is_locked ? 'yes' : 'no' ); ?>"
+									href="<?php echo esc_url( admin_url( 'edit.php?post_type=giftcard&page=wps-wgc-setting-lite&tab=' . $key ) ); ?>"
+								>
+									<span class="wps_wgm_nav_tab_title"><?php echo esc_html( $wps_tab['title'] ); ?></span>
+									<?php if ( $is_locked ) : ?>
+									<span class="wps_wgm_nav_badge"><?php esc_html_e( 'Pro', 'woo-gift-cards-lite' ); ?></span>
+								<?php endif; ?>
+							</a>
+						</div>
+					<?php endforeach; ?>
+
+					<?php if ( ! empty( $overflow_setting_tabs ) ) : ?>
+						<div class="wps_wgm_tabs wps_wgm_tabs_more">
+							<button
+								type="button"
+								class="<?php echo esc_attr( implode( ' ', array_filter( array( 'wps_wgm_nav_tab', 'wps_wgm_nav_tab_more', 'nav-tab', $is_overflow_active ? 'nav-tab-active' : '' ) ) ) ); ?>"
+								aria-expanded="false"
+							>
+								<span class="wps_wgm_nav_tab_title"><?php esc_html_e( 'More', 'woo-gift-cards-lite' ); ?></span>
+								<span class="wps_wgm_more_caret">▼</span>
+							</button>
+							<div class="wps_wgm_more_menu">
+									<?php foreach ( $overflow_setting_tabs as $key => $wps_tab ) : ?>
+										<?php $is_locked = ( ! $is_pro_active && ! in_array( $key, $lite_visible_tabs, true ) ); ?>
+										<a
+											class="wps_wgm_more_menu_link<?php echo esc_attr( $active_tab === $key ? ' is-active' : '' ); ?><?php echo esc_attr( $is_locked ? ' is-locked' : '' ); ?>"
+											href="<?php echo esc_url( admin_url( 'edit.php?post_type=giftcard&page=wps-wgc-setting-lite&tab=' . $key ) ); ?>"
+										>
+											<?php echo esc_html( $wps_tab['title'] ); ?>
+											<?php if ( $is_locked ) : ?>
+											<span class="wps_wgm_nav_badge"><?php esc_html_e( 'Pro', 'woo-gift-cards-lite' ); ?></span>
+										<?php endif; ?>
+									</a>
+								<?php endforeach; ?>
+							</div>
+						</div>
+					<?php endif; ?>
+				</div>
+
+				<div class="wps_wgm_content_template">
+					<div class="wps_wgm_content_shell">
+						<header class="wps_wgm_content_header">
+							<div class="wps_wgm_content_header_copy">
+								<span class="wps_wgm_content_header_eyebrow"><?php esc_html_e( 'Settings', 'woo-gift-cards-lite' ); ?></span>
+								<h2><?php echo esc_html( $active_tab_title ); ?></h2>
+								<p><?php echo esc_html( $active_tab_description ); ?></p>
+								<?php if ( ! empty( $dashboard_top_notice ) ) : ?>
+									<div class="wps_wgm_dashboard_page_notice wps_wgm_dashboard_page_notice_<?php echo esc_attr( $dashboard_top_notice['type'] ); ?>">
+										<p><?php echo esc_html( $dashboard_top_notice['message'] ); ?></p>
+										<button type="button" class="notice-dismiss">
+											<span class="screen-reader-text"><?php esc_html_e( 'Dismiss notice.', 'woo-gift-cards-lite' ); ?></span>
+										</button>
+									</div>
+								<?php endif; ?>
+							</div>
+							<div class="wps_wgm_content_header_actions">
+								<a class="wps_wgm_dashboard_action" href="<?php echo esc_url( $help_links[1]['url'] ); ?>" target="_blank"><?php esc_html_e( 'Read Documentation', 'woo-gift-cards-lite' ); ?></a>
+							</div>
+						</header>
+
+						<div class="wps_wgm_content_layout">
+								<div class="wps_wgm_content_panel">
+									<?php
+									foreach ( $visible_setting_tabs as $key => $wps_file ) {
+										if ( $active_tab !== $key ) {
+											continue;
+										}
+
+									$include_tab = isset( $wps_file['file_path'] ) ? $wps_file['file_path'] : '';
+									if ( ! empty( $include_tab ) ) {
+										include_once $include_tab;
+									}
+									break;
+								}
+								?>
+							</div>
+
+							<aside class="wps_wgm_dashboard_sidebar">
+								<div class="wps_wgm_sidebar_card">
+									<h3><?php esc_html_e( 'Need help with this plugin?', 'woo-gift-cards-lite' ); ?></h3>
+									<div class="wps_wgm_sidebar_links">
+										<a class="wps_wgm_sidebar_link" href="<?php echo esc_url( $help_links[0]['url'] ); ?>" target="_blank"><?php echo esc_html( $help_links[0]['label'] ); ?></a>
+										<a class="wps_wgm_sidebar_link" href="<?php echo esc_url( $help_links[1]['url'] ); ?>" target="_blank"><?php echo esc_html( $help_links[1]['label'] ); ?></a>
+										<a class="wps_wgm_sidebar_link" href="<?php echo esc_url( $help_links[2]['url'] ); ?>" target="_blank"><?php echo esc_html__( 'Support', 'woo-gift-cards-lite' ); ?></a>
+									</div>
+								</div>
+
+								<div class="wps_wgm_sidebar_card wps_wgm_sidebar_card_tint">
+									<h3><?php esc_html_e( 'Still facing problems?', 'woo-gift-cards-lite' ); ?></h3>
+									<p><?php esc_html_e( 'We are ready to resolve workflow, styling, and integration issues across your store setup.', 'woo-gift-cards-lite' ); ?></p>
+									<div class="wps_wgm_sidebar_links">
+										<a class="wps_wgm_sidebar_link wps_wgm_sidebar_link_primary" href="<?php echo esc_url( $help_links[2]['url'] ); ?>" target="_blank"><?php echo esc_html( $help_links[2]['label'] ); ?></a>
+									</div>
+								</div>
+
+								<div class="wps_wgm_sidebar_card">
+									<h3><?php esc_html_e( 'Explore more plugins', 'woo-gift-cards-lite' ); ?></h3>
+									<p><?php esc_html_e( 'Discover additional commerce and automation plugins from the same product family.', 'woo-gift-cards-lite' ); ?></p>
+									<div class="wps_wgm_sidebar_links">
+										<a class="wps_wgm_sidebar_link" href="<?php echo esc_url( $help_links[3]['url'] ); ?>" target="_blank"><?php echo esc_html__( 'View More Plugins', 'woo-gift-cards-lite' ); ?></a>
+									</div>
+								</div>
+							</aside>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	</form>


### PR DESCRIPTION
## Task Link
WPS-6570

## Summary
Redesigned the WooCommerce Gift Cards Lite admin dashboard. The main admin display template was refactored to use a clean content shell with a header (tab title, description, documentation link), a sidebar with help and support links, and a "More" dropdown for overflow tabs. The Overview tab was replaced with a feature-card grid layout. Button and input styles were updated across the admin CSS to match the new design direction.

## Changes Made
- Refactored `admin/partials/woocommerce-gift-cards-lite-admin-display.php`: deduplicated settings tab array, extracted `$is_pro_active`, rewrote tab nav with class arrays and `data-locked` attribute, added overflow "More" dropdown, added content header with tab title/description/doc link, added right sidebar with help cards
- Redesigned `admin/partials/templates/wps-wgm-overview-setting.php`: replaced video iframe layout with hero section + 5-feature card grid + support CTA
- Updated `admin/css/woocommerce_gift_cards_lite-admin.css`: pill-style black buttons, updated overview content selector, fixed redeem registration input widths
- Added `admin/css/wpswings-onboarding-admin.css` styles for the new onboarding/sidebar components
- Minor JS updates in `admin/js/woocommerce_gift_cards_lite-admin.js` for "More" dropdown toggle

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Tab active state when no `tab` query param (defaults to overview)
  - Locked/Pro tabs render badge and `data-locked="yes"` correctly in both lite and pro modes
  - Overflow "More" dropdown shows/hides correctly
  - Sidebar renders on all settings tabs

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
