### PR TITLE
feature/WPS-6756-performance-optimization

### DIFF
--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -208,7 +208,7 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 					'ajaxurl' => admin_url( 'admin-ajax.php' ),
 					'wps_uwgc_report_nonce' => wp_create_nonce( 'wps-uwgc-giftcard-report-nonce' ),
 				);
-				wp_enqueue_script( 'wps_uwgc_report_js', plugin_dir_url( __FILE__ ) . 'js/ultimate-woocommerce-giftcard-report.js', array( 'jquery' ), $this->version, false );
+				wp_enqueue_script( 'wps_uwgc_report_js', plugin_dir_url( __FILE__ ) . 'js/ultimate-woocommerce-giftcard-report.js', array( 'jquery' ), $this->version, true );
 				wp_localize_script( 'wps_uwgc_report_js', 'ajax_object', $wps_uwgc_report_array );
 				wp_enqueue_script( 'thickbox' );
 				wp_enqueue_style( 'thickbox' );

--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -234,6 +234,8 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 					'ajaxurl'                => admin_url( 'admin-ajax.php' ),
 					'is_tax_enable_for_gift' => $giftcard_tax_cal_enable,
 					'wps_wgm_nonce'          => wp_create_nonce( 'wps-wgm-verify-nonce' ),
+					'wps_wgm_expert_action'  => Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form::AJAX_ACTION,
+					'wps_wgm_expert_nonce'   => wp_create_nonce( Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form::NONCE_ACTION ),
 					'decimal_separator'      => get_option( 'woocommerce_price_decimal_sep' ),
 				);
 				$url     = plugins_url();

--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -73,6 +73,78 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 	}
 
 	/**
+	 * Check whether Gift Card admin assets are needed on the current screen.
+	 *
+	 * @param bool $include_plugins Whether plugin-list notice assets are allowed.
+	 * @return bool
+	 */
+	private function wps_wgm_is_admin_asset_screen( $include_plugins = false ) {
+		$screen     = get_current_screen();
+		$pagescreen = isset( $screen->id ) ? $screen->id : '';
+		$page       = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		$tab        = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
+		$section    = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '';
+		$post_type  = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : '';
+
+		$allowed_screens = array(
+			'product',
+			'edit-product',
+			'giftcard',
+			'edit-giftcard',
+			'shop_order',
+			'edit-shop_order',
+			'woocommerce_page_wc-orders',
+			'shop_coupon',
+			'edit-shop_coupon',
+			'woocommerce_page_wc-reports',
+			'giftcard_page_wps-wgc-setting-lite',
+			'giftcard_page_uwgc-import-giftcard-templates',
+			'giftcard_page_giftcard-import-giftcard-templates',
+		);
+
+		if ( $include_plugins ) {
+			$allowed_screens[] = 'plugins';
+		}
+
+		$is_allowed = in_array( $pagescreen, $allowed_screens, true ) || in_array( $post_type, array( 'product', 'giftcard', 'shop_coupon', 'shop_order' ), true );
+
+		if ( 'wc-settings' === $page ) {
+			$is_allowed = false !== strpos( $tab, 'gift' ) || false !== strpos( $section, 'gift' );
+		}
+
+		if ( in_array( $page, array( 'wps-wgc-setting-lite', 'uwgc-import-giftcard-templates', 'giftcard-import-giftcard-templates' ), true ) ) {
+			$is_allowed = true;
+		}
+
+		return (bool) apply_filters( 'wps_wgm_admin_asset_screen_allowed', $is_allowed, $pagescreen, $page );
+	}
+
+	/**
+	 * Check import-template screens.
+	 *
+	 * @return bool
+	 */
+	private function wps_wgm_is_import_template_screen() {
+		$screen     = get_current_screen();
+		$pagescreen = isset( $screen->id ) ? $screen->id : '';
+		$page       = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+
+		return in_array( $pagescreen, array( 'giftcard_page_uwgc-import-giftcard-templates', 'giftcard_page_giftcard-import-giftcard-templates' ), true ) || in_array( $page, array( 'uwgc-import-giftcard-templates', 'giftcard-import-giftcard-templates' ), true );
+	}
+
+	/**
+	 * Check notice screens.
+	 *
+	 * @return bool
+	 */
+	private function wps_wgm_is_notice_admin_screen() {
+		$screen     = get_current_screen();
+		$pagescreen = isset( $screen->id ) ? $screen->id : '';
+
+		return in_array( $pagescreen, array( 'plugins', 'giftcard_page_wps-wgc-setting-lite' ), true );
+	}
+
+	/**
 	 * Register the stylesheets for the admin area.
 	 *
 	 * @since    1.0.0
@@ -96,13 +168,11 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 				wp_die( esc_html__( 'Nonce Not verified', 'woo-gift-cards-lite' ) );
 		}
 
-		$screen = get_current_screen();
-		wp_enqueue_script( 'thickbox' );
-		if ( isset( $screen->id ) ) {
-			$pagescreen = $screen->id;
-		}
 
-		if ( ( isset( $_GET['page'] ) && ( 'wps-wgc-setting-lite' === $_GET['page'] || 'wc-settings' == $_GET['page'] ) ) || ( isset( $_GET['post_type'] ) && 'product' === $_GET['post_type'] ) || ( isset( $_GET['post_type'] ) && 'giftcard' === $_GET['post_type'] ) || ( isset( $pagescreen ) && ( 'plugins' === $pagescreen || 'product' === $pagescreen || 'dashboard' == $pagescreen ) ) ) {
+		$screen     = get_current_screen();
+		$pagescreen = isset( $screen->id ) ? $screen->id : '';
+
+		if ( $this->wps_wgm_is_admin_asset_screen( true ) ) {
 			wp_enqueue_style( 'thickbox' );
 			wp_enqueue_style( 'select2' );
 			wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/woocommerce_gift_cards_lite-admin.css', array(), $this->version, 'all' );
@@ -110,9 +180,9 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 			wp_register_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), $this->version );
 			wp_enqueue_style( 'woocommerce_admin_menu_styles' );
 			wp_enqueue_style( 'woocommerce_admin_styles' );
-			if ( ! wps_uwgc_pro_active() ) {
+			if ( ! wps_uwgc_pro_active() && $this->wps_wgm_is_import_template_screen() ) {
 
-				wp_enqueue_style( $this->plugin_name . 'tmp', plugin_dir_url( __FILE__ ) . 'css/woocommerce_gift_cards_import_tmp.css', array(), time(), 'all' );
+				wp_enqueue_style( $this->plugin_name . 'tmp', plugin_dir_url( __FILE__ ) . 'css/woocommerce_gift_cards_import_tmp.css', array(), $this->version, 'all' );
 
 			}
 		}
@@ -125,23 +195,27 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 	 * @since    1.0.0
 	 */
 	public function wps_wgm_enqueue_scripts() {
-		$screen = get_current_screen();
+		$screen     = get_current_screen();
+		$pagescreen = isset( $screen->id ) ? $screen->id : '';
 
-		wp_enqueue_script( 'thickbox' );
+		if ( ! $this->wps_wgm_is_admin_asset_screen( true ) ) {
+			return;
+		}
 		if ( isset( $screen->id ) ) {
 			if ( wps_uwgc_pro_active() ) {
 				wp_enqueue_script( 'pro_tag_remove_class', plugin_dir_url( __FILE__ ) . '/js/wps_wgm_gift_card_pro_admin.js', array( 'jquery' ), $this->version, true );
 			}
-			$pagescreen = $screen->id;
 
-			$wps_wgm_notice = array(
-				'ajaxurl'       => admin_url( 'admin-ajax.php' ),
-				'wps_wgm_nonce' => wp_create_nonce( 'wps-wgm-verify-notice-nonce' ),
-				'is_pro_plugin_active' => wps_uwgc_pro_active(),
-			);
-			wp_register_script( $this->plugin_name . 'admin-notice', plugin_dir_url( __FILE__ ) . 'js/wps-wgm-gift-card-notices.js', array( 'jquery' ), $this->version, false );
-			wp_localize_script( $this->plugin_name . 'admin-notice', 'wps_wgm_notice', $wps_wgm_notice );
-			wp_enqueue_script( $this->plugin_name . 'admin-notice' );
+			if ( $this->wps_wgm_is_notice_admin_screen() ) {
+				$wps_wgm_notice = array(
+					'ajaxurl'       => admin_url( 'admin-ajax.php' ),
+					'wps_wgm_nonce' => wp_create_nonce( 'wps-wgm-verify-notice-nonce' ),
+					'is_pro_plugin_active' => wps_uwgc_pro_active(),
+				);
+				wp_register_script( $this->plugin_name . 'admin-notice', plugin_dir_url( __FILE__ ) . 'js/wps-wgm-gift-card-notices.js', array( 'jquery' ), $this->version, false );
+				wp_localize_script( $this->plugin_name . 'admin-notice', 'wps_wgm_notice', $wps_wgm_notice );
+				wp_enqueue_script( $this->plugin_name . 'admin-notice' );
+			}
 			if ( 'plugins' === $pagescreen ) {
 				return;
 			}
@@ -150,7 +224,8 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 				wp_enqueue_script( $this->plugin_name . 'wps_wgm_uneditable_template_name', plugin_dir_url( __FILE__ ) . 'js/wps_wgm_uneditable_template_name.js', array( 'jquery' ), $this->version, 'count' );
 			}
 
-			if ( 'product' === $pagescreen || 'shop_order' === $pagescreen || 'woocommerce_page_wc-orders' == $pagescreen || 'giftcard_page_wps-wgc-setting-lite' === $pagescreen || 'giftcard_page_uwgc-import-giftcard-templates' === $pagescreen || 'plugins' === $pagescreen || 'giftcard_page_giftcard-import-giftcard-templates' === $pagescreen ) {
+			if ( 'product' === $pagescreen || 'shop_order' === $pagescreen || 'woocommerce_page_wc-orders' == $pagescreen || 'giftcard_page_wps-wgc-setting-lite' === $pagescreen || 'giftcard_page_uwgc-import-giftcard-templates' === $pagescreen || 'giftcard_page_giftcard-import-giftcard-templates' === $pagescreen ) {
+				wp_enqueue_script( 'thickbox' );
 
 				$wps_wgm_general_settings = get_option( 'wps_wgm_general_settings', false );
 				$giftcard_tax_cal_enable  = $this->wps_common_fun->wps_wgm_get_template_data( $wps_wgm_general_settings, 'wps_wgm_general_setting_tax_cal_enable' );
@@ -584,7 +659,8 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 					}
 					$general_settings     = get_option( 'wps_wgm_general_settings', array() );
 					$wps_wgm_categ_enable = $this->wps_common_fun->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_categ_enable' );
-					if ( '' === $wps_wgm_categ_enable || 'off' === $wps_wgm_categ_enable ) {
+					wp_set_object_terms( $product_id, 'wgm_gift_card', 'product_type' );
+					if ( 'on' === $wps_wgm_categ_enable ) {
 						$term       = __( 'Gift Card', 'woo-gift-cards-lite' );
 						$taxonomy   = 'product_cat';
 						$term_exist = term_exists( $term, $taxonomy );
@@ -592,8 +668,7 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 							$args['slug'] = 'wps_wgm_giftcard';
 							$term_exist   = wp_insert_term( $term, $taxonomy, $args );
 						}
-						wp_set_object_terms( $product_id, 'wgm_gift_card', 'product_type' );
-						wp_set_post_terms( $product_id, $term_exist, $taxonomy );
+						wp_set_post_terms( $product_id, $term_exist, $taxonomy, true );
 					}
 					$wps_wgm_pricing  = array();
 					$selected_pricing = isset( $_POST['wps_wgm_pricing'] ) ? sanitize_text_field( wp_unslash( $_POST['wps_wgm_pricing'] ) ) : false;
@@ -1419,6 +1494,11 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 	 */
 	public function wps_get_update_notification_data() {
 		$wps_notification_data = array();
+
+		if ( ! apply_filters( 'wps_wgm_allow_remote_notification_fetch', true ) ) {
+			return $wps_notification_data;
+		}
+
 		$url                   = 'https://demo.wpswings.com/client-notification/woo-gift-cards-lite/wps-client-notify.php';
 		$attr                  = array(
 			'action'         => 'wps_notification_fetch',
@@ -1906,6 +1986,9 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 	public function wps_wgm_admin_toolbar() {
 		global $wp_admin_bar;
 		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		if ( ! apply_filters( 'wps_wgm_show_admin_toolbar_report', 'yes' === get_option( 'wps_wgm_enable_admin_toolbar_report', 'yes' ) ) ) {
 			return;
 		}
 
@@ -2497,57 +2580,68 @@ class Woocommerce_Gift_Cards_Lite_Admin {
      * Callback Gift Card Dashboard Widget.
      */
     public function wps_render_gift_card_dashboard_widget() {
-        $args = array(
-            'post_type'      => 'shop_coupon',
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-            'fields'         => 'ids',
-            'meta_query'     => array(
-                array(
-                    'key'     => 'wps_wgm_giftcard_coupon',
-                    'compare' => 'EXISTS',
+        $summary = get_transient( 'wps_wgm_gift_card_dashboard_summary' );
+        if ( false === $summary ) {
+            $args = array(
+                'post_type'      => 'shop_coupon',
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'fields'         => 'ids',
+                'meta_query'     => array(
+                    array(
+                        'key'     => 'wps_wgm_giftcard_coupon',
+                        'compare' => 'EXISTS',
+                    ),
                 ),
-            ),
-        );
+            );
  
-        $query = new WP_Query( $args );
+            $query = new WP_Query( $args );
  
-        $total_cards     = 0;
-        $total_issued    = 0;
-        $total_redeemed  = 0;
-        $total_remaining = 0;
-        $total_expired   = 0;
-        $current_time    = current_time( 'timestamp' );
+            $total_cards     = 0;
+            $total_issued    = 0;
+            $total_redeemed  = 0;
+            $total_remaining = 0;
+            $total_expired   = 0;
+            $current_time    = current_time( 'timestamp' );
  
-        if ( $query->have_posts() ) {
-            foreach ( $query->posts as $coupon_id ) {
-                $amount                     = (float) get_post_meta( $coupon_id, 'wps_wgm_coupon_amount', true );
-                $remaining                  = (float) get_post_meta( $coupon_id, 'coupon_amount', true );
-                $wps_gw_used_coupon_details = get_post_meta( $coupon_id, 'wps_uwgc_used_order_id', true );
+            if ( $query->have_posts() ) {
+                foreach ( $query->posts as $coupon_id ) {
+                    $amount                     = (float) get_post_meta( $coupon_id, 'wps_wgm_coupon_amount', true );
+                    $remaining                  = (float) get_post_meta( $coupon_id, 'coupon_amount', true );
+                    $wps_gw_used_coupon_details = get_post_meta( $coupon_id, 'wps_uwgc_used_order_id', true );
  
-                if ( isset( $wps_gw_used_coupon_details ) && is_array( $wps_gw_used_coupon_details ) && ! empty( $wps_gw_used_coupon_details ) ) {
-                    foreach ( $wps_gw_used_coupon_details as $key => $value ) {
-                        $total_redeemed += $value['used_amount'];
+                    if ( isset( $wps_gw_used_coupon_details ) && is_array( $wps_gw_used_coupon_details ) && ! empty( $wps_gw_used_coupon_details ) ) {
+                        foreach ( $wps_gw_used_coupon_details as $key => $value ) {
+                            $total_redeemed += $value['used_amount'];
+                        }
                     }
-                }
  
-                $expiry_timestamp = (int) get_post_meta( $coupon_id, 'date_expires', true );
-                if ( $expiry_timestamp > 0 && $expiry_timestamp < $current_time ) {
-                    $total_expired += $remaining;
-                }
+                    $expiry_timestamp = (int) get_post_meta( $coupon_id, 'date_expires', true );
+                    if ( $expiry_timestamp > 0 && $expiry_timestamp < $current_time ) {
+                        $total_expired += $remaining;
+                    }
  
-                $total_cards++;
-                $total_issued    += $amount;
-                $total_remaining += $remaining;
+                    $total_cards++;
+                    $total_issued    += $amount;
+                    $total_remaining += $remaining;
+                }
             }
+            $summary = array(
+                'total_cards'     => $total_cards,
+                'total_issued'    => $total_issued,
+                'total_redeemed'  => $total_redeemed,
+                'total_remaining' => $total_remaining,
+                'total_expired'   => $total_expired,
+            );
+            set_transient( 'wps_wgm_gift_card_dashboard_summary', $summary, 15 * MINUTE_IN_SECONDS );
         }
  
         echo '<ul style="list-style: disc; padding-left: 20px;">';
-        echo '<li><strong>' . esc_html__( 'Total Gift Cards Issued:', 'woo-gift-cards-lite' ) . '</strong> ' . esc_html( $total_cards ) . '</li>';
-        echo '<li><strong>' . esc_html__( 'Total Value Issued:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $total_issued ) ) . '</li>';
-        echo '<li><strong>' . esc_html__( 'Total Value Redeemed:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $total_redeemed ) ) . '</li>';
-        echo '<li><strong>' . esc_html__( 'Total Expired Value:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $total_expired ) ) . '</li>';
-        echo '<li><strong>' . esc_html__( 'Remaining Balance:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $total_remaining ) ) . '</li>';
+        echo '<li><strong>' . esc_html__( 'Total Gift Cards Issued:', 'woo-gift-cards-lite' ) . '</strong> ' . esc_html( $summary['total_cards'] ) . '</li>';
+        echo '<li><strong>' . esc_html__( 'Total Value Issued:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $summary['total_issued'] ) ) . '</li>';
+        echo '<li><strong>' . esc_html__( 'Total Value Redeemed:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $summary['total_redeemed'] ) ) . '</li>';
+        echo '<li><strong>' . esc_html__( 'Total Expired Value:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $summary['total_expired'] ) ) . '</li>';
+        echo '<li><strong>' . esc_html__( 'Remaining Balance:', 'woo-gift-cards-lite' ) . '</strong> ' . wp_kses_post( wc_price( $summary['total_remaining'] ) ) . '</li>';
         echo '</ul>';
     }
 

--- a/admin/css/woocommerce_gift_cards_lite-admin.css
+++ b/admin/css/woocommerce_gift_cards_lite-admin.css
@@ -4083,6 +4083,182 @@ th label[for=wps_wgm_new_gift_card_page_layout], th label[for=wps_wgm_select_lib
     color: #ffffff;
 }
 
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card.wps_wgm_sidebar_card_services {
+    padding: 22px 20px 24px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_header {
+    align-items: flex-start;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_services h3 {
+    font-size: 20px;
+    line-height: 1.15;
+    margin: 0 0 12px;
+    max-width: 190px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_badge {
+    align-items: center;
+    border: 1px solid #ffb33b;
+    border-radius: 14px;
+    display: inline-flex;
+    flex: 0 0 42px;
+    height: 42px;
+    justify-content: center;
+    width: 42px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_badge::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23ff9f05' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 5l1.6 4.1L18 10.1l-3.4 2.8.4 4.4-3-2.4-3 2.4.4-4.4L6 10.1l4.4-1z'/%3E%3C/svg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: "";
+    display: block;
+    height: 18px;
+    width: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_card_services p {
+    font-size: 13px;
+    line-height: 1.75;
+    margin: 0 0 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_item {
+    align-items: center;
+    background: linear-gradient(180deg, #fffefd 0%, #ffffff 100%);
+    border: 1px solid rgba(236, 231, 245, 0.95);
+    border-radius: 18px;
+    box-shadow: 0 12px 26px rgba(29, 18, 55, 0.05);
+    color: #1f1a44;
+    display: flex;
+    gap: 12px;
+    padding: 14px;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_item:hover,
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_item:focus {
+    border-color: #dbcceb;
+    box-shadow: 0 16px 30px rgba(29, 18, 55, 0.09);
+    color: #1f1a44;
+    transform: translateY(-1px);
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon {
+    align-items: center;
+    background: linear-gradient(180deg, #fbfbff 0%, #f1f1ff 100%);
+    border-radius: 999px;
+    display: inline-flex;
+    flex: 0 0 42px;
+    height: 42px;
+    justify-content: center;
+    position: relative;
+    width: 42px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon::before {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: "";
+    display: block;
+    height: 18px;
+    width: 18px;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon_seo {
+    background: linear-gradient(180deg, #fff8e6 0%, #fff1cb 100%);
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon_seo::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='%23f0aa0f' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Ccircle cx='10.5' cy='10.5' r='4.5'/%3E%3Cpath d='M14 14l5 5'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon_ads::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='%23735df6' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M6 14l3.7-6.4a1.5 1.5 0 0 1 2.6 0L16 14'/%3E%3Cpath d='M13.7 8.3L18 16'/%3E%3Cpath d='M11 10.5l2.2 3.8'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon_speed::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='%234970ff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M6 15a6 6 0 1 1 12 0'/%3E%3Cpath d='M12 12l2.5-2.5'/%3E%3Ccircle cx='12' cy='15' r='1' fill='%234970ff' stroke='none'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_icon_dev::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect x='3.5' y='5.5' width='17' height='13' rx='3' fill='none' stroke='%235b6bff' stroke-width='1.8'/%3E%3Ctext x='12' y='14.2' text-anchor='middle' font-family='Arial, sans-serif' font-size='6.5' font-weight='700' fill='%235b6bff'%3Ewoo%3C/text%3E%3C/svg%3E");
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_title {
+    color: #1f1a44;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.35;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_description {
+    color: #6f6982;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.5;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_arrow {
+    color: #6c5a97;
+    flex: 0 0 auto;
+    font-size: 24px;
+    font-weight: 800;
+    line-height: 1;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_button {
+    align-items: center;
+    background: #000000;
+    border: 0;
+    border-radius: 14px;
+    color: #ffffff;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: 800;
+    justify-content: center;
+    min-height: 48px;
+    padding: 12px 18px;
+    text-decoration: none;
+    width: 100%;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_button:hover,
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_button:focus {
+    color: #ffffff;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_service_rail_footer {
+    color: #8a849d;
+    font-size: 12px;
+    line-height: 1.5;
+    margin-top: 12px;
+    text-align: center;
+}
+
 /* Mail image upload row layout */
 #wps_wgm_setting_wrapper tr.wps_wgm_mail_setting_background_logo td.forminp.forminp-text,
 #wps_wgm_setting_wrapper tr.wps_wgm_mail_setting_upload_logo td.forminp.forminp-text {

--- a/admin/css/woocommerce_gift_cards_lite-admin.css
+++ b/admin/css/woocommerce_gift_cards_lite-admin.css
@@ -4083,6 +4083,696 @@ th label[for=wps_wgm_new_gift_card_page_layout], th label[for=wps_wgm_select_lib
     color: #ffffff;
 }
 
+/* Talk to an Expert service option checkbox style */
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #ded1fb;
+    border-radius: 14px;
+    box-shadow: none;
+    display: flex;
+    gap: 10px;
+    min-height: 47px;
+    padding: 10px 14px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input {
+    appearance: none;
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #d9c9ff;
+    border-radius: 999px;
+    box-shadow: none;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 15px;
+    height: 15px;
+    justify-content: center;
+    margin: 0;
+    min-height: 0;
+    min-width: 0;
+    padding: 0;
+    position: relative;
+    width: 15px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input::before {
+    background: transparent;
+    border: solid #2f86ff;
+    border-width: 0 1.7px 1.7px 0;
+    border-radius: 0;
+    box-shadow: none;
+    content: "";
+    display: block;
+    height: 7px;
+    left: 5px;
+    margin: 0;
+    opacity: 0;
+    position: absolute;
+    top: 2px;
+    transform: rotate(45deg);
+    transition: opacity 0.15s ease;
+    width: 4px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input:checked::before {
+    opacity: 1;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox span {
+    color: #43386c;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.3;
+}
+
+/* Talk to an Expert service option checkbox style */
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #ded1fb;
+    border-radius: 14px;
+    box-shadow: none;
+    display: flex;
+    gap: 10px;
+    min-height: 47px;
+    padding: 10px 14px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input {
+    appearance: none;
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #d9c9ff;
+    border-radius: 999px;
+    box-shadow: none;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 15px;
+    height: 15px;
+    justify-content: center;
+    margin: 0;
+    min-height: 0;
+    min-width: 0;
+    padding: 0;
+    position: relative;
+    width: 15px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input::before {
+    background: transparent;
+    border: solid #2f86ff;
+    border-width: 0 1.7px 1.7px 0;
+    border-radius: 0;
+    box-shadow: none;
+    content: "";
+    display: block;
+    height: 7px;
+    left: 5px;
+    margin: 0;
+    opacity: 0;
+    position: absolute;
+    top: 2px;
+    transform: rotate(45deg);
+    transition: opacity 0.15s ease;
+    width: 4px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input:checked::before {
+    opacity: 1;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox span {
+    color: #43386c;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.3;
+}
+
+/* Talk to an Expert modal reference-match overrides */
+.wps-wgm-expert-modal {
+    align-items: flex-start;
+    background: rgba(12, 10, 26, 0.64);
+    box-sizing: border-box;
+    overflow: auto;
+    padding: 18px 28px;
+}
+
+.wps-wgm-expert-modal__backdrop {
+    background: transparent;
+}
+
+.wps-wgm-expert-modal__dialog {
+    background: #f8f5ff;
+    border: 1px solid #ddd1f4;
+    border-radius: 22px;
+    box-shadow: 0 30px 80px rgba(15, 11, 32, 0.34);
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-height: calc(100vh - 36px);
+    max-width: 820px;
+    overflow-y: auto;
+    scrollbar-color: #898989 transparent;
+    scrollbar-width: auto;
+    width: min(820px, calc(100vw - 56px));
+}
+
+.wps-wgm-expert-modal__dialog::-webkit-scrollbar {
+    width: 12px;
+}
+
+.wps-wgm-expert-modal__dialog::-webkit-scrollbar-thumb {
+    background: #898989;
+    border-radius: 999px;
+}
+
+.wps-wgm-expert-modal__dialog::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.wps-wgm-expert-modal__close {
+    background: #ffffff;
+    border: 1px solid #e2d9f2;
+    border-radius: 999px;
+    color: #2b2051;
+    font-size: 28px;
+    height: 40px;
+    right: 18px;
+    top: 18px;
+    width: 40px;
+}
+
+.wps-wgm-expert-modal__close:hover,
+.wps-wgm-expert-modal__close:focus {
+    background: #ffffff;
+    color: #2b2051;
+}
+
+.wps-wgm-expert-modal__header {
+    background: #ffffff;
+    border-bottom: 1px solid #e5dcf2;
+    padding: 30px 36px 28px;
+}
+
+.wps-wgm-expert-modal__header h2 {
+    color: #120b35;
+    font-size: 30px;
+    font-weight: 800;
+    letter-spacing: 0;
+    line-height: 1.15;
+    margin: 0 52px 12px 0;
+}
+
+.wps-wgm-expert-modal__header p {
+    color: #6f668b;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.55;
+    margin: 0;
+    max-width: none;
+}
+
+.wps-wgm-expert-modal__panel {
+    background: #f8f5ff;
+    padding: 30px 36px 32px;
+}
+
+.wps-wgm-expert-modal__form {
+    gap: 16px;
+}
+
+.wps-wgm-expert-modal__grid {
+    column-gap: 16px;
+    row-gap: 14px;
+}
+
+.wps-wgm-expert-modal__field {
+    gap: 10px;
+}
+
+.wps-wgm-expert-modal__field label,
+.wps-wgm-expert-modal__legend {
+    color: #0d0730;
+    font-size: 13px;
+    font-weight: 800;
+}
+
+.wps-wgm-expert-modal__field input,
+.wps-wgm-expert-modal__field select,
+.wps-wgm-expert-modal__field textarea {
+    background: #ffffff;
+    border: 1px solid #ded1fb;
+    border-radius: 14px;
+    color: #120b35;
+    font-size: 14px;
+    min-height: 50px;
+    padding: 13px 16px;
+}
+
+.wps-wgm-expert-modal__field input::placeholder,
+.wps-wgm-expert-modal__field textarea::placeholder {
+    color: #9b91b9;
+}
+
+.wps-wgm-expert-modal__field select {
+    max-width: 400px;
+}
+
+.wps-wgm-expert-modal__field textarea {
+    min-height: 108px;
+}
+
+.wps-wgm-expert-modal__checkboxes {
+    gap: 10px 12px;
+}
+
+.wps-wgm-expert-modal__checkbox {
+    background: #ffffff;
+    border: 1px solid #ded1fb;
+    border-radius: 14px;
+    box-sizing: border-box;
+    gap: 14px;
+    min-height: 68px;
+    padding: 14px 16px 14px 14px;
+}
+
+.wps-wgm-expert-modal__checkbox input {
+    appearance: none;
+    background: #9c9c9c;
+    border: 0;
+    border-radius: 999px;
+    box-shadow: none;
+    cursor: pointer;
+    flex: 0 0 26px;
+    height: 46px;
+    margin: 0;
+    min-width: 0;
+    position: relative;
+    width: 26px;
+}
+
+.wps-wgm-expert-modal__checkbox input::before {
+    background: #ffffff;
+    border-radius: 999px;
+    box-shadow: 0 2px 5px rgba(12, 8, 28, 0.18);
+    content: "";
+    height: 20px;
+    left: -7px;
+    margin: 0;
+    position: absolute;
+    top: 13px;
+    transition: transform 0.18s ease;
+    width: 20px;
+}
+
+.wps-wgm-expert-modal__checkbox input:checked {
+    background: #7b61ff;
+}
+
+.wps-wgm-expert-modal__checkbox input:checked::before {
+    transform: translateX(20px);
+}
+
+.wps-wgm-expert-modal__checkbox span {
+    color: #150f39;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.28;
+}
+
+.wps-wgm-expert-modal__actions {
+    justify-content: flex-end;
+    margin-top: 4px;
+}
+
+.wps-wgm-expert-modal__submit {
+    background: #000000;
+    border-radius: 12px;
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 800;
+    min-height: 48px;
+    min-width: 146px;
+}
+
+@media only screen and (max-width: 782px) {
+    .wps-wgm-expert-modal {
+        padding: 10px;
+    }
+
+    .wps-wgm-expert-modal__dialog {
+        max-height: calc(100vh - 20px);
+        width: calc(100vw - 20px);
+    }
+
+    .wps-wgm-expert-modal__header,
+    .wps-wgm-expert-modal__panel {
+        padding-left: 24px;
+        padding-right: 24px;
+    }
+
+    .wps-wgm-expert-modal__checkbox {
+        min-height: 62px;
+    }
+}
+
+body.wps-wgm-expert-modal-open {
+    overflow: hidden;
+}
+
+#wps_wgm_setting_wrapper .wps_wgm_sidebar_services_button {
+    cursor: pointer;
+}
+
+.wps-wgm-expert-modal {
+    align-items: center;
+    display: flex;
+    inset: 0;
+    justify-content: center;
+    position: fixed;
+    z-index: 100000;
+}
+
+.wps-wgm-expert-modal[hidden] {
+    display: none;
+}
+
+.wps-wgm-expert-modal__backdrop {
+    background: rgba(12, 8, 28, 0.62);
+    inset: 0;
+    position: absolute;
+}
+
+.wps-wgm-expert-modal__dialog {
+    background: #f8f6ff;
+    border: 1px solid #eee7fb;
+    border-radius: 24px;
+    box-shadow: 0 30px 90px rgba(14, 8, 35, 0.32);
+    max-height: calc(100vh - 48px);
+    max-width: 720px;
+    overflow: auto;
+    position: relative;
+    width: calc(100% - 32px);
+}
+
+.wps-wgm-expert-modal__close {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #e7e0f3;
+    border-radius: 999px;
+    color: #27224d;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 24px;
+    height: 40px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    position: absolute;
+    right: 18px;
+    top: 18px;
+    width: 40px;
+    z-index: 2;
+}
+
+.wps-wgm-expert-modal__header {
+    background: #ffffff;
+    border-bottom: 1px solid #ebe4f6;
+    padding: 32px 36px 24px;
+}
+
+.wps-wgm-expert-modal__header h2 {
+    color: #1f1a44;
+    font-size: 30px;
+    font-weight: 800;
+    line-height: 1.2;
+    margin: 0 48px 10px 0;
+}
+
+.wps-wgm-expert-modal__header p {
+    color: #6f6982;
+    font-size: 14px;
+    line-height: 1.7;
+    margin: 0;
+    max-width: 520px;
+}
+
+.wps-wgm-expert-modal__panel {
+    padding: 28px 36px 34px;
+}
+
+.wps-wgm-expert-modal__status {
+    border-radius: 12px;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.5;
+    margin-bottom: 16px;
+    padding: 12px 14px;
+}
+
+.wps-wgm-expert-modal__status.is-success {
+    background: #ecfff2;
+    color: #137333;
+}
+
+.wps-wgm-expert-modal__status.is-error {
+    background: #fff0f0;
+    color: #b42318;
+}
+
+.wps-wgm-expert-modal__form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.wps-wgm-expert-modal__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.wps-wgm-expert-modal__field--span-2 {
+    grid-column: span 2;
+}
+
+.wps-wgm-expert-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.wps-wgm-expert-modal__field label,
+.wps-wgm-expert-modal__legend {
+    color: #1f1a44;
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 1.45;
+}
+
+.wps-wgm-expert-modal__required {
+    color: #d92d20;
+}
+
+.wps-wgm-expert-modal__field input,
+.wps-wgm-expert-modal__field select,
+.wps-wgm-expert-modal__field textarea {
+    background: #ffffff;
+    border: 1px solid #e4def0;
+    border-radius: 14px;
+    box-shadow: none;
+    color: #27224d;
+    font-size: 14px;
+    min-height: 46px;
+    padding: 10px 14px;
+    width: 100%;
+}
+
+.wps-wgm-expert-modal__field input::placeholder,
+.wps-wgm-expert-modal__field textarea::placeholder {
+    color: #9b94ad;
+}
+
+.wps-wgm-expert-modal__field textarea {
+    min-height: 112px;
+    resize: vertical;
+}
+
+.wps-wgm-expert-modal__field input:focus,
+.wps-wgm-expert-modal__field select:focus,
+.wps-wgm-expert-modal__field textarea:focus {
+    border-color: #8f7cff;
+    box-shadow: 0 0 0 3px rgba(143, 124, 255, 0.14);
+    outline: none;
+}
+
+.wps-wgm-expert-modal__checkboxes {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.wps-wgm-expert-modal__checkbox {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #e7e0f3;
+    border-radius: 14px;
+    cursor: pointer;
+    display: flex;
+    gap: 10px;
+    min-height: 46px;
+    padding: 10px 12px;
+}
+
+.wps-wgm-expert-modal__checkbox input {
+    flex: 0 0 auto;
+    height: 16px;
+    margin: 0;
+    width: 16px;
+}
+
+.wps-wgm-expert-modal__checkbox span {
+    color: #27224d;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.35;
+}
+
+.wps-wgm-expert-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.wps-wgm-expert-modal__submit {
+    align-items: center;
+    background: #000000;
+    border: 0;
+    border-radius: 14px;
+    color: #ffffff;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: 800;
+    justify-content: center;
+    min-height: 48px;
+    min-width: 158px;
+    padding: 12px 22px;
+}
+
+.wps-wgm-expert-modal__submit:hover,
+.wps-wgm-expert-modal__submit:focus {
+    background: #161616;
+    color: #ffffff;
+}
+
+.wps-wgm-expert-modal__submit:disabled {
+    cursor: wait;
+    opacity: 0.72;
+}
+
+.wps-wgm-expert-modal__success {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    justify-content: center;
+    min-height: 300px;
+    opacity: 0;
+    text-align: center;
+    transform: translateY(8px);
+    transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.wps-wgm-expert-modal__success[hidden] {
+    display: none;
+}
+
+.wps-wgm-expert-modal__success.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.wps-wgm-expert-modal__success-mark {
+    align-items: center;
+    display: inline-flex;
+    height: 84px;
+    justify-content: center;
+    position: relative;
+    width: 84px;
+}
+
+.wps-wgm-expert-modal__success-ring,
+.wps-wgm-expert-modal__success-core {
+    border-radius: 999px;
+    position: absolute;
+}
+
+.wps-wgm-expert-modal__success-ring {
+    background: #e9fff0;
+    height: 84px;
+    width: 84px;
+}
+
+.wps-wgm-expert-modal__success-core {
+    align-items: center;
+    background: #15b35f;
+    color: #ffffff;
+    display: inline-flex;
+    height: 54px;
+    justify-content: center;
+    width: 54px;
+}
+
+.wps-wgm-expert-modal__success-core svg {
+    height: 30px;
+    position: relative;
+    width: 30px;
+}
+
+.wps-wgm-expert-modal__success h3 {
+    color: #1f1a44;
+    font-size: 24px;
+    font-weight: 800;
+    margin: 8px 0 0;
+}
+
+.wps-wgm-expert-modal__success p {
+    color: #6f6982;
+    font-size: 14px;
+    line-height: 1.6;
+    margin: 0;
+    max-width: 420px;
+}
+
+@media only screen and (max-width: 782px) {
+    .wps-wgm-expert-modal__grid,
+    .wps-wgm-expert-modal__checkboxes {
+        grid-template-columns: 1fr;
+    }
+
+    .wps-wgm-expert-modal__field--span-2 {
+        grid-column: auto;
+    }
+
+    .wps-wgm-expert-modal__dialog {
+        max-height: calc(100vh - 24px);
+        width: calc(100% - 20px);
+    }
+
+    .wps-wgm-expert-modal__header {
+        padding: 26px 22px 20px;
+    }
+
+    .wps-wgm-expert-modal__header h2 {
+        font-size: 24px;
+        margin-right: 42px;
+    }
+
+    .wps-wgm-expert-modal__panel {
+        padding: 22px;
+    }
+}
+
 #wps_wgm_setting_wrapper .wps_wgm_sidebar_card.wps_wgm_sidebar_card_services {
     padding: 22px 20px 24px;
 }
@@ -4876,4 +5566,67 @@ body.wp-admin #wps_wgm_setting_wrapper .wps_wgm_content_panel p.submit.wps_wgm_f
 #wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:hover,
 #wps_wgm_setting_wrapper .wps_wgm_sidebar_link_primary:focus {
     color: #ffffff;
+}
+
+/* Final Talk to an Expert service option checkbox style */
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox {
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #ded1fb;
+    border-radius: 14px;
+    box-shadow: none;
+    display: flex;
+    gap: 10px;
+    min-height: 47px;
+    padding: 10px 14px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input {
+    appearance: none;
+    align-items: center;
+    background: #ffffff;
+    border: 1px solid #d9c9ff;
+    border-radius: 999px;
+    box-shadow: none;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 15px;
+    height: 15px;
+    justify-content: center;
+    margin: 0;
+    min-height: 0;
+    min-width: 0;
+    padding: 0;
+    position: relative;
+    width: 15px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input::before {
+    background: transparent;
+    border: solid #2f86ff;
+    border-width: 0 1.7px 1.7px 0;
+    border-radius: 0;
+    box-shadow: none;
+    content: "";
+    display: block;
+    height: 7px;
+    left: 5px;
+    margin: 0;
+    opacity: 0;
+    position: absolute;
+    top: 2px;
+    transform: rotate(45deg);
+    transition: opacity 0.15s ease;
+    width: 4px;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox input:checked::before {
+    opacity: 1;
+}
+
+.wps-wgm-expert-modal .wps-wgm-expert-modal__checkbox span {
+    color: #43386c;
+    font-size: 14px;
+    font-weight: 800;
+    line-height: 1.3;
 }

--- a/admin/js/woocommerce_gift_cards_lite-admin.js
+++ b/admin/js/woocommerce_gift_cards_lite-admin.js
@@ -573,4 +573,203 @@
 			);
 		}
 	);
+
+	$(function() {
+		var modalSelector = '[data-wps-wgm-expert-modal]';
+		var openTriggerSelector = '[data-wps-wgm-open-expert-modal]';
+		var closeTriggerSelector = '[data-wps-wgm-expert-modal-close]';
+		var formSelector = '[data-wps-wgm-expert-modal-form]';
+		var statusSelector = '[data-wps-wgm-expert-modal-status]';
+		var successSelector = '[data-wps-wgm-expert-modal-success]';
+		var successMessageSelector = '[data-wps-wgm-expert-modal-success-message]';
+		var bodyLockClass = 'wps-wgm-expert-modal-open';
+		var successCloseTimer = null;
+
+		function wpsWgmGetExpertModal() {
+			return $( modalSelector ).first();
+		}
+
+		function wpsWgmSetExpertStatus( $modal, message, statusType ) {
+			var $status = $modal.find( statusSelector ).first();
+
+			if ( ! $status.length ) {
+				return;
+			}
+
+			if ( ! message ) {
+				$status.attr( 'hidden', true ).removeClass( 'is-success is-error' ).text( '' );
+				return;
+			}
+
+			$status.removeAttr( 'hidden' ).removeClass( 'is-success is-error' ).addClass( 'is-' + statusType ).text( message );
+		}
+
+		function wpsWgmResetExpertModalState( $modal ) {
+			var $form = $modal.find( formSelector ).first();
+			var $success = $modal.find( successSelector ).first();
+			var $successMessage = $modal.find( successMessageSelector ).first();
+			var $submitButton = $form.find( 'button[type="submit"]' ).first();
+
+			if ( $form.length ) {
+				if ( $form.get( 0 ) && 'function' === typeof $form.get( 0 ).reset ) {
+					$form.get( 0 ).reset();
+				}
+
+				$form.removeAttr( 'hidden' );
+			}
+
+			if ( $submitButton.length ) {
+				$submitButton
+					.prop( 'disabled', false )
+					.text( $submitButton.attr( 'data-submit-label' ) || 'Submit Request' );
+			}
+
+			if ( $success.length ) {
+				$success.attr( 'hidden', true ).removeClass( 'is-visible' );
+			}
+
+			if ( $successMessage.length ) {
+				$successMessage.text( 'Thank you for submitting your request.' );
+			}
+
+			wpsWgmSetExpertStatus( $modal, '', '' );
+		}
+
+		function wpsWgmShowExpertSuccessState( $modal, message ) {
+			var $form = $modal.find( formSelector ).first();
+			var $success = $modal.find( successSelector ).first();
+			var $successMessage = $modal.find( successMessageSelector ).first();
+
+			if ( $form.length ) {
+				$form.attr( 'hidden', true );
+			}
+
+			wpsWgmSetExpertStatus( $modal, '', '' );
+
+			if ( $successMessage.length ) {
+				$successMessage.text( message );
+			}
+
+			if ( $success.length ) {
+				$success.removeAttr( 'hidden' );
+
+				window.setTimeout( function() {
+					$success.addClass( 'is-visible' );
+				}, 20 );
+			}
+		}
+
+		function wpsWgmToggleExpertModal( shouldOpen ) {
+			var $modal = wpsWgmGetExpertModal();
+
+			if ( ! $modal.length ) {
+				return;
+			}
+
+			if ( successCloseTimer ) {
+				window.clearTimeout( successCloseTimer );
+				successCloseTimer = null;
+			}
+
+			if ( shouldOpen ) {
+				$modal.removeAttr( 'hidden' );
+				$( 'body' ).addClass( bodyLockClass );
+				wpsWgmResetExpertModalState( $modal );
+				return;
+			}
+
+			$modal.attr( 'hidden', true );
+			$( 'body' ).removeClass( bodyLockClass );
+			wpsWgmResetExpertModalState( $modal );
+		}
+
+		function wpsWgmNormalizeExpertPayload( formElement ) {
+			var payload = {};
+			var formData = new window.FormData( formElement );
+
+			formData.forEach( function( value, key ) {
+				var normalizedKey = key.replace( /\[\]$/, '' );
+
+				if ( Object.prototype.hasOwnProperty.call( payload, normalizedKey ) ) {
+					if ( ! Array.isArray( payload[ normalizedKey ] ) ) {
+						payload[ normalizedKey ] = [ payload[ normalizedKey ] ];
+					}
+
+					payload[ normalizedKey ].push( value );
+					return;
+				}
+
+				payload[ normalizedKey ] = value;
+			} );
+
+			return payload;
+		}
+
+		$( document ).off( 'click.wpsWgmExpertModalOpen', openTriggerSelector ).on( 'click.wpsWgmExpertModalOpen', openTriggerSelector, function(event) {
+			event.preventDefault();
+			wpsWgmToggleExpertModal( true );
+		} );
+
+		$( document ).off( 'click.wpsWgmExpertModalClose', closeTriggerSelector ).on( 'click.wpsWgmExpertModalClose', closeTriggerSelector, function(event) {
+			event.preventDefault();
+			wpsWgmToggleExpertModal( false );
+		} );
+
+		$( document ).off( 'keydown.wpsWgmExpertModal' ).on( 'keydown.wpsWgmExpertModal', function(event) {
+			if ( 'Escape' === event.key ) {
+				wpsWgmToggleExpertModal( false );
+			}
+		} );
+
+		$( document ).off( 'submit.wpsWgmExpertModal', formSelector ).on( 'submit.wpsWgmExpertModal', formSelector, function(event) {
+			var $form = $( this );
+			var $modal = $form.closest( modalSelector );
+			var $submitButton = $form.find( 'button[type="submit"]' ).first();
+			var submitLabel = $submitButton.attr( 'data-submit-label' ) || $submitButton.text();
+			var loadingLabel = $submitButton.attr( 'data-loading-label' ) || 'Sending...';
+
+			event.preventDefault();
+			wpsWgmSetExpertStatus( $modal, '', '' );
+			$submitButton.prop( 'disabled', true ).text( loadingLabel );
+
+			$.ajax( {
+				url: wps_wgc.ajaxurl,
+				type: 'POST',
+				dataType: 'json',
+				data: {
+					action: wps_wgc.wps_wgm_expert_action,
+					nonce: wps_wgc.wps_wgm_expert_nonce,
+					form_data: JSON.stringify( wpsWgmNormalizeExpertPayload( $form.get( 0 ) ) )
+				}
+			} ).done( function( response ) {
+				var isSuccess = !! ( response && response.success );
+				var message = response && response.data && response.data.message ? response.data.message : '';
+
+				if ( ! message ) {
+					message = isSuccess ? 'Thank you for submitting your request.' : 'We could not submit your request right now. Please try again.';
+				}
+
+				if ( isSuccess && message ) {
+					wpsWgmShowExpertSuccessState( $modal, message );
+
+					successCloseTimer = window.setTimeout( function() {
+						wpsWgmToggleExpertModal( false );
+					}, 3000 );
+					return;
+				}
+
+				wpsWgmSetExpertStatus( $modal, message, 'error' );
+			} ).fail( function( xhr ) {
+				var message = 'We could not submit your request right now. Please try again.';
+
+				if ( xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message ) {
+					message = xhr.responseJSON.data.message;
+				}
+
+				wpsWgmSetExpertStatus( $modal, message, 'error' );
+			} ).always( function() {
+				$submitButton.prop( 'disabled', false ).text( submitLabel );
+			} );
+		} );
+	});
 })( jQuery );

--- a/admin/partials/woocommerce-gift-cards-lite-admin-display.php
+++ b/admin/partials/woocommerce-gift-cards-lite-admin-display.php
@@ -195,7 +195,7 @@ $help_links = array(
 	),
 );
 
-$wps_wgm_services_link = 'https://wpswings.com/woocommerce-services/?utm_source=wpswings-giftcards-services&utm_medium=giftcards-org-backend&utm_campaign=woocommerce-services';
+$wps_wgm_services_link = Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form::wps_wgm_get_services_landing_url();
 $wps_wgm_marketing_services = array(
 	array(
 		'icon'        => 'seo',
@@ -408,7 +408,7 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 											</a>
 										<?php endforeach; ?>
 									</div>
-									<a class="wps_wgm_sidebar_services_button" href="<?php echo esc_url( $wps_wgm_services_link ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Talk to an Expert', 'woo-gift-cards-lite' ); ?></a>
+									<button type="button" class="wps_wgm_sidebar_services_button" data-wps-wgm-open-expert-modal><?php esc_html_e( 'Talk to an Expert', 'woo-gift-cards-lite' ); ?></button>
 									<div class="wps_wgm_service_rail_footer"><?php esc_html_e( 'Services by WP Swings', 'woo-gift-cards-lite' ); ?></div>
 								</div>
 								<div class="wps_wgm_sidebar_card wps_wgm_sidebar_card_tint">
@@ -433,4 +433,5 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 			</div>
 		</div>
 	</form>
+	<?php Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form::wps_wgm_render_modal(); ?>
 </div>

--- a/admin/partials/woocommerce-gift-cards-lite-admin-display.php
+++ b/admin/partials/woocommerce-gift-cards-lite-admin-display.php
@@ -238,6 +238,15 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 
 		<div class="wps_wgm_dashboard_shell">
 
+			<?php if ( ! empty( $dashboard_top_notice ) ) : ?>
+				<div class="wps_wgm_dashboard_page_notice wps_wgm_dashboard_page_notice_<?php echo esc_attr( $dashboard_top_notice['type'] ); ?>">
+					<p><?php echo esc_html( $dashboard_top_notice['message'] ); ?></p>
+					<button type="button" class="notice-dismiss">
+						<span class="screen-reader-text"><?php esc_html_e( 'Dismiss notice.', 'woo-gift-cards-lite' ); ?></span>
+					</button>
+				</div>
+			<?php endif; ?>
+
 			<div class="wps_wgm_dashboard_notice_stack">
 				<div class="wps_wgm_dashboard_notice wps_wgm_dashboard_notice_status">
 					<div class="wps_wgm_dashboard_notice_badge wps_wgm_dashboard_notice_badge_dark">
@@ -324,14 +333,6 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 								<span class="wps_wgm_content_header_eyebrow"><?php esc_html_e( 'Settings', 'woo-gift-cards-lite' ); ?></span>
 								<h2><?php echo esc_html( $active_tab_title ); ?></h2>
 								<p><?php echo esc_html( $active_tab_description ); ?></p>
-								<?php if ( ! empty( $dashboard_top_notice ) ) : ?>
-									<div class="wps_wgm_dashboard_page_notice wps_wgm_dashboard_page_notice_<?php echo esc_attr( $dashboard_top_notice['type'] ); ?>">
-										<p><?php echo esc_html( $dashboard_top_notice['message'] ); ?></p>
-										<button type="button" class="notice-dismiss">
-											<span class="screen-reader-text"><?php esc_html_e( 'Dismiss notice.', 'woo-gift-cards-lite' ); ?></span>
-										</button>
-									</div>
-								<?php endif; ?>
 							</div>
 							<div class="wps_wgm_content_header_actions">
 								<a class="wps_wgm_dashboard_action" href="<?php echo esc_url( $help_links[1]['url'] ); ?>" target="_blank"><?php esc_html_e( 'Read Documentation', 'woo-gift-cards-lite' ); ?></a>

--- a/admin/partials/woocommerce-gift-cards-lite-admin-display.php
+++ b/admin/partials/woocommerce-gift-cards-lite-admin-display.php
@@ -195,6 +195,30 @@ $help_links = array(
 	),
 );
 
+$wps_wgm_services_link = 'https://wpswings.com/woocommerce-services/?utm_source=wpswings-giftcards-services&utm_medium=giftcards-org-backend&utm_campaign=woocommerce-services';
+$wps_wgm_marketing_services = array(
+	array(
+		'icon'        => 'seo',
+		'title'       => esc_html__( 'SEO Services', 'woo-gift-cards-lite' ),
+		'description' => esc_html__( 'Improve rankings & organic traffic', 'woo-gift-cards-lite' ),
+	),
+	array(
+		'icon'        => 'ads',
+		'title'       => esc_html__( 'Google Ads Setup And G4 Setup', 'woo-gift-cards-lite' ),
+		'description' => esc_html__( 'Run profitable ad campaigns', 'woo-gift-cards-lite' ),
+	),
+	array(
+		'icon'        => 'speed',
+		'title'       => esc_html__( 'Speed Optimization', 'woo-gift-cards-lite' ),
+		'description' => esc_html__( 'Faster store, happier customers', 'woo-gift-cards-lite' ),
+	),
+	array(
+		'icon'        => 'dev',
+		'title'       => esc_html__( 'WooCommerce Development Services', 'woo-gift-cards-lite' ),
+		'description' => esc_html__( 'Custom Solution For your store needs', 'woo-gift-cards-lite' ),
+	),
+);
+
 $secure_nonce = wp_create_nonce( 'wps-gc-auth-nonce' );
 $id_nonce_verified = wp_verify_nonce( $secure_nonce, 'wps-gc-auth-nonce' );
 if ( ! $id_nonce_verified ) {
@@ -366,6 +390,27 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 									</div>
 								</div>
 
+								<div class="wps_wgm_sidebar_card wps_wgm_sidebar_card_services">
+									<div class="wps_wgm_sidebar_services_header">
+										<h3><?php esc_html_e( 'Grow Your Store With WP Swings', 'woo-gift-cards-lite' ); ?></h3>
+										<span class="wps_wgm_sidebar_services_badge" aria-hidden="true"></span>
+									</div>
+									<p><?php esc_html_e( "Expert solutions to boost your store's performance.", 'woo-gift-cards-lite' ); ?></p>
+									<div class="wps_wgm_service_rail">
+										<?php foreach ( $wps_wgm_marketing_services as $wps_wgm_marketing_service ) : ?>
+											<a class="wps_wgm_service_rail_item" href="<?php echo esc_url( $wps_wgm_services_link ); ?>" target="_blank" rel="noopener noreferrer">
+												<span class="wps_wgm_service_rail_icon wps_wgm_service_rail_icon_<?php echo esc_attr( $wps_wgm_marketing_service['icon'] ); ?>" aria-hidden="true"></span>
+												<span class="wps_wgm_service_rail_content">
+													<span class="wps_wgm_service_rail_title"><?php echo esc_html( $wps_wgm_marketing_service['title'] ); ?></span>
+													<span class="wps_wgm_service_rail_description"><?php echo esc_html( $wps_wgm_marketing_service['description'] ); ?></span>
+												</span>
+												<span class="wps_wgm_service_rail_arrow" aria-hidden="true">&rsaquo;</span>
+											</a>
+										<?php endforeach; ?>
+									</div>
+									<a class="wps_wgm_sidebar_services_button" href="<?php echo esc_url( $wps_wgm_services_link ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Talk to an Expert', 'woo-gift-cards-lite' ); ?></a>
+									<div class="wps_wgm_service_rail_footer"><?php esc_html_e( 'Services by WP Swings', 'woo-gift-cards-lite' ); ?></div>
+								</div>
 								<div class="wps_wgm_sidebar_card wps_wgm_sidebar_card_tint">
 									<h3><?php esc_html_e( 'Still facing problems?', 'woo-gift-cards-lite' ); ?></h3>
 									<p><?php esc_html_e( 'We are ready to resolve workflow, styling, and integration issues across your store setup.', 'woo-gift-cards-lite' ); ?></p>

--- a/includes/class-makewebbetter-onboarding-helper.php
+++ b/includes/class-makewebbetter-onboarding-helper.php
@@ -126,8 +126,7 @@ class Makewebbetter_Onboarding_Helper {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'admin_footer', array( $this, 'add_onboarding_popup_screen' ) );
-		add_action( 'admin_footer', array( $this, 'add_deactivation_popup_screen' ) );
+		add_action( 'current_screen', array( $this, 'register_popup_footer_hooks' ) );
 		add_filter( 'wps_on_boarding_form_fields', array( $this, 'add_on_boarding_form_fields' ) );
 		add_filter( 'wps_deactivation_form_fields', array( $this, 'add_deactivation_form_fields' ) );
 
@@ -139,6 +138,20 @@ class Makewebbetter_Onboarding_Helper {
 		add_action( 'wp_ajax_skip_onboarding_popup', array( $this, 'skip_onboarding_popup' ) );
 		add_action( 'wp_ajax_nopriv_skip_onboarding_popup', array( $this, 'skip_onboarding_popup' ) );
 
+	}
+
+	/**
+	 * Register popup footer hooks only on screens where they can render.
+	 *
+	 * @return void
+	 */
+	public function register_popup_footer_hooks() {
+		if ( ! $this->is_valid_page_screen() ) {
+			return;
+		}
+
+		add_action( 'admin_footer', array( $this, 'add_onboarding_popup_screen' ) );
+		add_action( 'admin_footer', array( $this, 'add_deactivation_popup_screen' ) );
 	}
 
 

--- a/includes/class-woocommerce-gift-cards-common-function.php
+++ b/includes/class-woocommerce-gift-cards-common-function.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 				$giftcard_logo_html = '';
 				$giftcard_featured = '';
 				$giftcard_event_html = '';
-				$wps_wgm_mail_settings = get_option( 'wps_wgm_mail_settings', array() );
+				$wps_wgm_mail_settings = wps_wgm_get_plugin_option( 'wps_wgm_mail_settings' );
 				$giftcard_upload_logo = $this->wps_wgm_get_template_data( $wps_wgm_mail_settings, 'wps_wgm_mail_setting_upload_logo' );
 
 				$giftcard_logo_height = $this->wps_wgm_get_template_data( $wps_wgm_mail_settings, 'wps_wgm_mail_setting_upload_logo_dimension_height' );
@@ -76,7 +76,7 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 				}
 				$featured_image = wp_get_attachment_url( get_post_thumbnail_id( $templateid ) );
 
-				$other_settings              = get_option( 'wps_wgm_other_settings', array() );
+				$other_settings              = wps_wgm_get_plugin_option( 'wps_wgm_other_settings' );
 				$wps_wgm_select_library = $this->wps_wgm_get_template_data( $other_settings, 'wps_wgm_select_library' );
 
 				if ( isset( $background_image ) && ! empty( $background_image ) ) {
@@ -126,13 +126,12 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 
 				if ( wps_uwgc_pro_active() ) {
 
-					$general_settings = get_option( 'wps_wgm_general_settings', array() );
+					$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
 
-					$wps_obj = new Woocommerce_Gift_Cards_Common_Function();
-					$selected_date = $wps_obj->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_enable_selected_format' );
+					$selected_date = $this->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_enable_selected_format' );
 
 					if ( '' != $selected_date || ! empty( $selected_date ) ) {
-							$giftcard_selected_date  = $wps_obj->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_enable_selected_date' );
+							$giftcard_selected_date  = $this->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_enable_selected_date' );
 
 						if ( isset( $giftcard_selected_date ) ) {
 							$selected_date = $selected_date;
@@ -219,20 +218,41 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 				}
 				$args['variable_price_description'] = isset( $args['variable_price_description'] ) ? $args['variable_price_description'] : '';
 
-				$templatehtml = str_replace( '[ARROWIMAGE]', $arrow_img, $templatehtml );
-				$templatehtml = str_replace( '[BACK]', $mothers_day_backimg, $templatehtml );
-				$templatehtml = str_replace( '[LOGO]', $giftcard_logo_html, $templatehtml );
-				$templatehtml = str_replace( '[AMOUNT]', $args['amount'], $templatehtml );
-				$templatehtml = str_replace( '[COUPON]', $args['coupon'], $templatehtml );
-				$templatehtml = str_replace( '[EXPIRYDATE]', $args['expirydate'], $templatehtml );
-				$templatehtml = str_replace( '[PURCHASEDATE]', $formatted_purchase_date, $templatehtml );
-				$templatehtml = str_replace( '[DISCLAIMER]', $giftcard_disclaimer, $templatehtml );
-				$templatehtml = str_replace( '[DELIVERYMETHOD]', $args['delivery_method'], $templatehtml );
-				$templatehtml = str_replace( '[VARIABLEDESCRIPTION]', $args['variable_price_description'], $templatehtml );
-				$templatehtml = str_replace( '[RECOMMENDEDPRODUCT]', $recommand_product, $templatehtml );
-				$templatehtml = str_replace( '[DEFAULTEVENT]', $giftcard_event_html, $templatehtml );
-				$templatehtml = str_replace( '[FEATUREDIMAGE]', $giftcard_featured, $templatehtml );
-				$templatehtml = str_replace( '[BGIMAGE]', $bgimg, $templatehtml );
+				$templatehtml = str_replace(
+					array(
+						'[ARROWIMAGE]',
+						'[BACK]',
+						'[LOGO]',
+						'[AMOUNT]',
+						'[COUPON]',
+						'[EXPIRYDATE]',
+						'[PURCHASEDATE]',
+						'[DISCLAIMER]',
+						'[DELIVERYMETHOD]',
+						'[VARIABLEDESCRIPTION]',
+						'[RECOMMENDEDPRODUCT]',
+						'[DEFAULTEVENT]',
+						'[FEATUREDIMAGE]',
+						'[BGIMAGE]',
+					),
+					array(
+						$arrow_img,
+						$mothers_day_backimg,
+						$giftcard_logo_html,
+						$args['amount'],
+						$args['coupon'],
+						$args['expirydate'],
+						$formatted_purchase_date,
+						$giftcard_disclaimer,
+						$args['delivery_method'],
+						$args['variable_price_description'],
+						$recommand_product,
+						$giftcard_event_html,
+						$giftcard_featured,
+						$bgimg,
+					),
+					$templatehtml
+				);
 				$templatehtml = $template_css . $templatehtml;
 				$templatehtml = apply_filters( 'wps_wgm_email_template_html', $templatehtml, $args );
 				return $templatehtml;
@@ -297,8 +317,8 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 						$coupon_obj = new WC_Coupon( $new_coupon_id );
 						$coupon_obj->save();
 					}
-					$general_settings = get_option( 'wps_wgm_general_settings', array() );
-					$product_settings = get_option( 'wps_wgm_product_settings', array() );
+					$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
+					$product_settings = wps_wgm_get_plugin_option( 'wps_wgm_product_settings' );
 					$individual_use = $this->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_giftcard_individual_use' );
 					$individual_use = ( 'on' == $individual_use ) ? 'yes' : 'no';
 
@@ -498,7 +518,7 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 				}
 
 				if ( $get_mail_status ) {
-					$wps_wgm_mail_settings = get_option( 'wps_wgm_mail_settings', array() );
+					$wps_wgm_mail_settings = wps_wgm_get_plugin_option( 'wps_wgm_mail_settings' );
 
 					$send_subject = $this->wps_wgm_get_template_data( $wps_wgm_mail_settings, 'wps_wgm_mail_setting_giftcard_subject' );
 
@@ -598,7 +618,7 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 			if ( ! $id_nonce_verified ) {
 					wp_die( esc_html__( 'Nonce Not verified', 'woo-gift-cards-lite' ) );
 			}
-			$general_settings = get_option( 'wps_wgm_general_settings', array() );
+			$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
 			$selected_date = $this->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_enable_selected_format' );
 			$todaydate = date_i18n( 'Y-m-d' );
 			if ( isset( $expiry_date ) && ! empty( $expiry_date ) ) {
@@ -943,7 +963,7 @@ if ( ! class_exists( 'Woocommerce_Gift_Cards_Common_Function' ) ) {
 				return $discount;
 			}
 
-			$general_settings = get_option( 'wps_wgm_general_settings', array() );
+			$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
 			$max_percent = $this->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_giftcard_max_percent' );
 			$max_percent = is_numeric( $max_percent ) ? (float) $max_percent : 0;
 			if ( $max_percent <= 0 ) {

--- a/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
+++ b/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
@@ -1,0 +1,728 @@
+<?php
+/**
+ * Handle the admin Talk to an Expert workflow.
+ *
+ * @package woo-gift-cards-lite
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Talk to an Expert form handler.
+ */
+class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
+
+	/**
+	 * Ajax action name.
+	 *
+	 * @var string
+	 */
+	const AJAX_ACTION = 'wps_wgm_submit_talk_to_expert';
+
+	/**
+	 * Ajax nonce action.
+	 *
+	 * @var string
+	 */
+	const NONCE_ACTION = 'wps_wgm_talk_to_expert_nonce';
+
+	/**
+	 * HubSpot portal id.
+	 *
+	 * @var string
+	 */
+	const HUBSPOT_PORTAL_ID = '25444144';
+
+	/**
+	 * HubSpot form id.
+	 *
+	 * @var string
+	 */
+	const HUBSPOT_FORM_ID = 'eab973a7-5c65-4264-a31d-3b1b10b82c82';
+
+	/**
+	 * Get the marketing-services URL used across the card.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_services_landing_url() {
+		return 'https://wpswings.com/woocommerce-services/?utm_source=wpswings-giftcards-services&utm_medium=giftcards-org-backend&utm_campaign=woocommerce-services';
+	}
+
+	/**
+	 * Get service option labels keyed by submitted slug values.
+	 *
+	 * @return array
+	 */
+	public static function wps_wgm_get_service_options() {
+		return array(
+			'seo_services'                      => esc_html__( 'SEO services', 'woo-gift-cards-lite' ),
+			'google_ads_setup_and_ga4_setup'   => esc_html__( 'Google Ads Setup and GA4 setup', 'woo-gift-cards-lite' ),
+			'speed_optimization'               => esc_html__( 'Speed Optimization', 'woo-gift-cards-lite' ),
+			'woocommerce_development_services' => esc_html__( 'WooCommerce Development Services', 'woo-gift-cards-lite' ),
+		);
+	}
+
+	/**
+	 * Get budget option labels keyed by submitted values.
+	 *
+	 * @return array
+	 */
+	public static function wps_wgm_get_budget_options() {
+		return array(
+			''            => esc_html__( 'Please Select', 'woo-gift-cards-lite' ),
+			'500-1000'    => '$500 - $1000',
+			'1001-5000'   => '$1001 - $5000',
+			'5001-10000'  => '$5001 - $10000',
+			'10001-15000' => '$10001 - $15000',
+		);
+	}
+
+	/**
+	 * Get default field values from the current user.
+	 *
+	 * @return array
+	 */
+	public static function wps_wgm_get_default_form_values() {
+		$user       = function_exists( 'wp_get_current_user' ) ? wp_get_current_user() : null;
+		$first_name = ! empty( $user->user_firstname ) ? (string) $user->user_firstname : '';
+		$last_name  = ! empty( $user->user_lastname ) ? (string) $user->user_lastname : '';
+		$email      = ! empty( $user->user_email ) ? (string) $user->user_email : '';
+
+		if ( ( '' === $first_name || '' === $last_name ) && ! empty( $user->display_name ) ) {
+			$display_name_parts = preg_split( '/\s+/', trim( (string) $user->display_name ) );
+
+			if ( '' === $first_name && ! empty( $display_name_parts[0] ) ) {
+				$first_name = $display_name_parts[0];
+			}
+
+			if ( '' === $last_name && count( $display_name_parts ) > 1 ) {
+				array_shift( $display_name_parts );
+				$last_name = implode( ' ', $display_name_parts );
+			}
+		}
+
+		return array(
+			'firstname' => $first_name,
+			'lastname'  => $last_name,
+			'email'     => $email,
+			'phone'     => '',
+			'budget'    => '',
+			'message'   => '',
+		);
+	}
+
+	/**
+	 * Derive the plugin label from the target plugin context.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_plugin_label() {
+		$plugin_file = defined( 'WPS_WGC_DIRPATH' ) ? WPS_WGC_DIRPATH . 'woocommerce_gift_cards_lite.php' : '';
+
+		if ( $plugin_file && function_exists( 'get_file_data' ) && file_exists( $plugin_file ) ) {
+			$plugin_data = get_file_data(
+				$plugin_file,
+				array(
+					'name' => 'Plugin Name',
+				)
+			);
+
+			if ( ! empty( $plugin_data['name'] ) ) {
+				return (string) $plugin_data['name'];
+			}
+		}
+
+		return defined( 'WPS_WGC_ONBOARD_PLUGIN_NAME' ) ? (string) WPS_WGC_ONBOARD_PLUGIN_NAME : 'Ultimate Gift Cards For WooCommerce';
+	}
+
+	/**
+	 * Render the modal markup.
+	 *
+	 * @return void
+	 */
+	public static function wps_wgm_render_modal() {
+		$defaults        = self::wps_wgm_get_default_form_values();
+		$service_options = self::wps_wgm_get_service_options();
+		$budget_options  = self::wps_wgm_get_budget_options();
+		?>
+		<div class="wps-wgm-expert-modal" data-wps-wgm-expert-modal hidden>
+			<div class="wps-wgm-expert-modal__backdrop" data-wps-wgm-expert-modal-close></div>
+			<div class="wps-wgm-expert-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="wps-wgm-expert-modal-title">
+				<button type="button" class="wps-wgm-expert-modal__close" data-wps-wgm-expert-modal-close aria-label="<?php echo esc_attr__( 'Close Talk to an Expert form', 'woo-gift-cards-lite' ); ?>">
+					<span aria-hidden="true">&times;</span>
+				</button>
+				<div class="wps-wgm-expert-modal__header">
+					<h2 id="wps-wgm-expert-modal-title"><?php esc_html_e( 'Talk to an Expert', 'woo-gift-cards-lite' ); ?></h2>
+					<p><?php esc_html_e( 'Share your store goals and our team will reach out with the right next step.', 'woo-gift-cards-lite' ); ?></p>
+				</div>
+				<div class="wps-wgm-expert-modal__panel">
+					<div class="wps-wgm-expert-modal__status" data-wps-wgm-expert-modal-status hidden aria-live="polite"></div>
+					<form class="wps-wgm-expert-modal__form" data-wps-wgm-expert-modal-form>
+						<div class="wps-wgm-expert-modal__grid">
+							<div class="wps-wgm-expert-modal__field">
+								<label for="wps_wgm_expert_firstname"><?php esc_html_e( 'First Name', 'woo-gift-cards-lite' ); ?></label>
+								<input id="wps_wgm_expert_firstname" type="text" name="firstname" value="<?php echo esc_attr( $defaults['firstname'] ); ?>" placeholder="<?php esc_attr_e( 'John', 'woo-gift-cards-lite' ); ?>" autocomplete="given-name">
+							</div>
+							<div class="wps-wgm-expert-modal__field">
+								<label for="wps_wgm_expert_lastname"><?php esc_html_e( 'Last Name', 'woo-gift-cards-lite' ); ?></label>
+								<input id="wps_wgm_expert_lastname" type="text" name="lastname" value="<?php echo esc_attr( $defaults['lastname'] ); ?>" placeholder="<?php esc_attr_e( 'Doe', 'woo-gift-cards-lite' ); ?>" autocomplete="family-name">
+							</div>
+							<div class="wps-wgm-expert-modal__field wps-wgm-expert-modal__field--span-2">
+								<label for="wps_wgm_expert_email"><?php esc_html_e( 'Work Email', 'woo-gift-cards-lite' ); ?> <span class="wps-wgm-expert-modal__required">*</span></label>
+								<input id="wps_wgm_expert_email" type="email" name="email" value="<?php echo esc_attr( $defaults['email'] ); ?>" required placeholder="<?php esc_attr_e( 'name@yourstore.com', 'woo-gift-cards-lite' ); ?>" autocomplete="email">
+							</div>
+							<div class="wps-wgm-expert-modal__field">
+								<label for="wps_wgm_expert_phone"><?php esc_html_e( 'Contact Number', 'woo-gift-cards-lite' ); ?></label>
+								<input id="wps_wgm_expert_phone" type="text" name="phone" value="<?php echo esc_attr( $defaults['phone'] ); ?>" placeholder="<?php esc_attr_e( '+1 000 000 0000', 'woo-gift-cards-lite' ); ?>">
+							</div>
+						</div>
+						<div class="wps-wgm-expert-modal__field">
+							<span class="wps-wgm-expert-modal__legend"><?php esc_html_e( 'What services do you need help with?', 'woo-gift-cards-lite' ); ?></span>
+							<div class="wps-wgm-expert-modal__checkboxes">
+								<?php foreach ( $service_options as $service_key => $service_label ) : ?>
+									<label class="wps-wgm-expert-modal__checkbox">
+										<input type="checkbox" name="what_services_do_you_need_help_with[]" value="<?php echo esc_attr( $service_key ); ?>">
+										<span><?php echo esc_html( $service_label ); ?></span>
+									</label>
+								<?php endforeach; ?>
+							</div>
+						</div>
+						<div class="wps-wgm-expert-modal__field">
+							<label for="wps_wgm_expert_budget"><?php esc_html_e( 'Budget', 'woo-gift-cards-lite' ); ?></label>
+							<select id="wps_wgm_expert_budget" name="budget">
+								<?php foreach ( $budget_options as $budget_value => $budget_label ) : ?>
+									<option value="<?php echo esc_attr( $budget_value ); ?>"<?php echo '' === $budget_value ? ' selected disabled' : ''; ?>><?php echo esc_html( $budget_label ); ?></option>
+								<?php endforeach; ?>
+							</select>
+						</div>
+						<div class="wps-wgm-expert-modal__field">
+							<label for="wps_wgm_expert_message"><?php esc_html_e( 'What do you need help with?', 'woo-gift-cards-lite' ); ?></label>
+							<textarea id="wps_wgm_expert_message" name="message" rows="4" placeholder="<?php esc_attr_e( 'Share your goals, blockers, or the service you need.', 'woo-gift-cards-lite' ); ?>"><?php echo esc_textarea( $defaults['message'] ); ?></textarea>
+						</div>
+						<div class="wps-wgm-expert-modal__actions">
+							<button
+								type="submit"
+								class="wps-wgm-expert-modal__submit"
+								data-submit-label="<?php echo esc_attr__( 'Submit Request', 'woo-gift-cards-lite' ); ?>"
+								data-loading-label="<?php echo esc_attr__( 'Sending...', 'woo-gift-cards-lite' ); ?>"
+							><?php esc_html_e( 'Submit Request', 'woo-gift-cards-lite' ); ?></button>
+						</div>
+					</form>
+					<div class="wps-wgm-expert-modal__success" data-wps-wgm-expert-modal-success hidden aria-live="polite">
+						<div class="wps-wgm-expert-modal__success-mark" aria-hidden="true">
+							<span class="wps-wgm-expert-modal__success-ring"></span>
+							<span class="wps-wgm-expert-modal__success-core">
+								<svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+									<path d="M6.5 12.5l3.4 3.4L17.8 8" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+								</svg>
+							</span>
+						</div>
+						<h3><?php esc_html_e( 'Thank you', 'woo-gift-cards-lite' ); ?></h3>
+						<p data-wps-wgm-expert-modal-success-message><?php esc_html_e( 'Thank you for submitting your request.', 'woo-gift-cards-lite' ); ?></p>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handle the admin ajax submission.
+	 *
+	 * @return void
+	 */
+	public function wps_wgm_handle_ajax_submission() {
+		check_ajax_referer( self::NONCE_ACTION, 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'You are not allowed to submit this request.', 'woo-gift-cards-lite' ),
+				),
+				403
+			);
+		}
+
+		$form_data = isset( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
+		$form_data = is_string( $form_data ) ? json_decode( $form_data, true ) : array();
+
+		if ( ! is_array( $form_data ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Invalid request payload.', 'woo-gift-cards-lite' ),
+				),
+				400
+			);
+		}
+
+		$sanitized_data = self::wps_wgm_sanitize_submission( $form_data );
+
+		if ( empty( $sanitized_data['email'] ) || ! is_email( $sanitized_data['email'] ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'Please enter a valid email address.', 'woo-gift-cards-lite' ),
+				),
+				400
+			);
+		}
+
+		$response = wp_remote_post( self::wps_wgm_get_hubspot_endpoint(), self::wps_wgm_get_hubspot_request_args( $sanitized_data ) );
+
+		if ( is_wp_error( $response ) ) {
+			wp_send_json_error(
+				array(
+					'message' => esc_html__( 'We could not submit your request right now. Please try again.', 'woo-gift-cards-lite' ),
+				),
+				500
+			);
+		}
+
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$message       = self::wps_wgm_get_hubspot_response_message( $response_body, $response_code );
+
+		if ( $response_code >= 200 && $response_code < 300 ) {
+			wp_send_json_success(
+				array(
+					'message' => $message,
+				)
+			);
+		}
+
+		wp_send_json_error(
+			array(
+				'message' => $message,
+			),
+			$response_code > 0 ? $response_code : 500
+		);
+	}
+
+	/**
+	 * Sanitize the posted form payload.
+	 *
+	 * @param array $form_data Raw form data.
+	 * @return array
+	 */
+	public static function wps_wgm_sanitize_submission( $form_data ) {
+		$form_data          = is_array( $form_data ) ? $form_data : array();
+		$services           = self::wps_wgm_get_service_options();
+		$budgets            = self::wps_wgm_get_budget_options();
+		$submitted_services = array();
+
+		if ( isset( $form_data['what_services_do_you_need_help_with'] ) ) {
+			$raw_services = wp_unslash( $form_data['what_services_do_you_need_help_with'] );
+
+			if ( ! is_array( $raw_services ) ) {
+				$raw_services = array( $raw_services );
+			}
+
+			$submitted_services = array_filter(
+				array_map( 'sanitize_text_field', $raw_services ),
+				static function( $service ) {
+					return '' !== $service;
+				}
+			);
+		}
+
+		$valid_services = array_values( array_intersect( array_keys( $services ), $submitted_services ) );
+
+		$budget = isset( $form_data['budget'] ) ? sanitize_text_field( wp_unslash( $form_data['budget'] ) ) : '';
+		if ( ! array_key_exists( $budget, $budgets ) || '' === $budget ) {
+			$budget = '';
+		}
+
+		return array(
+			'firstname'                          => isset( $form_data['firstname'] ) ? sanitize_text_field( wp_unslash( $form_data['firstname'] ) ) : '',
+			'lastname'                           => isset( $form_data['lastname'] ) ? sanitize_text_field( wp_unslash( $form_data['lastname'] ) ) : '',
+			'email'                              => isset( $form_data['email'] ) ? sanitize_email( wp_unslash( $form_data['email'] ) ) : '',
+			'phone'                              => isset( $form_data['phone'] ) ? sanitize_text_field( wp_unslash( $form_data['phone'] ) ) : '',
+			'what_services_do_you_need_help_with' => $valid_services,
+			'budget'                             => $budget,
+			'message'                            => isset( $form_data['message'] ) ? sanitize_textarea_field( wp_unslash( $form_data['message'] ) ) : '',
+			'annualrevenue'                      => self::wps_wgm_get_annual_revenue_last_12_months(),
+		);
+	}
+
+	/**
+	 * Build the wp_remote_post arguments for HubSpot.
+	 *
+	 * @param array $sanitized_data Clean form data.
+	 * @return array
+	 */
+	public static function wps_wgm_get_hubspot_request_args( $sanitized_data ) {
+		$payload = self::wps_wgm_build_hubspot_payload( $sanitized_data );
+
+		return array(
+			'method'      => 'POST',
+			'timeout'     => 45,
+			'redirection' => 5,
+			'httpversion' => '1.0',
+			'blocking'    => true,
+			'headers'     => array(
+				'Content-Type' => 'application/json',
+			),
+			'body'        => wp_json_encode(
+				array(
+					'fields'  => $payload['fields'],
+					'context' => array(
+						'pageUri'   => admin_url( 'edit.php?post_type=giftcard&page=wps-wgc-setting-lite' ),
+						'pageName'  => self::wps_wgm_get_plugin_label(),
+						'ipAddress' => self::wps_wgm_get_client_ip(),
+					),
+				)
+			),
+			'cookies'     => array(),
+		);
+	}
+
+	/**
+	 * Build the HubSpot payload.
+	 *
+	 * @param array $sanitized_data Clean form data.
+	 * @return array
+	 */
+	public static function wps_wgm_build_hubspot_payload( $sanitized_data ) {
+		$selected_services = ! empty( $sanitized_data['what_services_do_you_need_help_with'] ) && is_array( $sanitized_data['what_services_do_you_need_help_with'] )
+			? array_values( $sanitized_data['what_services_do_you_need_help_with'] )
+			: array();
+
+		$fields = array(
+			self::wps_wgm_maybe_build_hubspot_field( 'firstname', isset( $sanitized_data['firstname'] ) ? $sanitized_data['firstname'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'lastname', isset( $sanitized_data['lastname'] ) ? $sanitized_data['lastname'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'email', isset( $sanitized_data['email'] ) ? $sanitized_data['email'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'phone', isset( $sanitized_data['phone'] ) ? $sanitized_data['phone'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'what_services_do_you_need_help_with', $selected_services ),
+			self::wps_wgm_maybe_build_hubspot_field( 'budget', isset( $sanitized_data['budget'] ) ? $sanitized_data['budget'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'message', isset( $sanitized_data['message'] ) ? $sanitized_data['message'] : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'currency', self::wps_wgm_get_store_currency() ),
+			self::wps_wgm_maybe_build_hubspot_field( 'org_plugin_name', self::wps_wgm_get_plugin_label() ),
+			self::wps_wgm_maybe_build_hubspot_field( 'company', function_exists( 'get_bloginfo' ) ? get_bloginfo( 'name' ) : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'website', function_exists( 'home_url' ) ? home_url( '/' ) : '' ),
+			self::wps_wgm_maybe_build_hubspot_field( 'country', self::wps_wgm_get_store_country_label() ),
+			self::wps_wgm_maybe_build_hubspot_field( 'annualrevenue', isset( $sanitized_data['annualrevenue'] ) ? $sanitized_data['annualrevenue'] : self::wps_wgm_get_annual_revenue_last_12_months() ),
+		);
+
+		return array(
+			'fields' => array_values( array_filter( $fields ) ),
+		);
+	}
+
+	/**
+	 * Build a single HubSpot field if it has a non-empty value.
+	 *
+	 * @param string       $field_name Field name.
+	 * @param string|array $field_value Field value.
+	 * @return array|null
+	 */
+	public static function wps_wgm_maybe_build_hubspot_field( $field_name, $field_value ) {
+		if ( is_array( $field_value ) ) {
+			$field_value = implode(
+				';',
+				array_values(
+					array_filter(
+						array_map( 'strval', $field_value ),
+						static function( $value ) {
+							return '' !== $value;
+						}
+					)
+				)
+			);
+		}
+
+		if ( null === $field_value ) {
+			return null;
+		}
+
+		$field_value = is_scalar( $field_value ) ? trim( (string) $field_value ) : '';
+
+		if ( '' === $field_value ) {
+			return null;
+		}
+
+		return array(
+			'name'  => (string) $field_name,
+			'value' => $field_value,
+		);
+	}
+
+	/**
+	 * Clean the HubSpot inline message before it is shown.
+	 *
+	 * @param string $message Raw message.
+	 * @return string
+	 */
+	public static function wps_wgm_clean_response_message( $message ) {
+		$message = is_string( $message ) ? $message : '';
+
+		if ( '' === $message ) {
+			return '';
+		}
+
+		$charset = function_exists( 'get_bloginfo' ) ? get_bloginfo( 'charset' ) : 'UTF-8';
+		$message = wp_strip_all_tags( $message );
+		$message = html_entity_decode( $message, ENT_QUOTES, $charset ? $charset : 'UTF-8' );
+		$message = preg_replace( '/[\x{00A0}\s]+/u', ' ', $message );
+
+		return trim( (string) $message );
+	}
+
+	/**
+	 * Get the HubSpot endpoint.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_hubspot_endpoint() {
+		return 'https://api.hsforms.com/submissions/v3/integration/submit/' . self::HUBSPOT_PORTAL_ID . '/' . self::HUBSPOT_FORM_ID;
+	}
+
+	/**
+	 * Resolve the client IP address for HubSpot context.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_client_ip() {
+		$ip_headers = array(
+			'HTTP_CF_CONNECTING_IP',
+			'HTTP_X_FORWARDED_FOR',
+			'HTTP_X_REAL_IP',
+			'REMOTE_ADDR',
+		);
+
+		foreach ( $ip_headers as $header_key ) {
+			if ( empty( $_SERVER[ $header_key ] ) ) {
+				continue;
+			}
+
+			$raw_value = wp_unslash( $_SERVER[ $header_key ] );
+			$ip_list   = is_string( $raw_value ) ? explode( ',', $raw_value ) : array( $raw_value );
+
+			foreach ( $ip_list as $ip_candidate ) {
+				$ip_candidate = trim( sanitize_text_field( (string) $ip_candidate ) );
+
+				if ( filter_var( $ip_candidate, FILTER_VALIDATE_IP ) ) {
+					return $ip_candidate;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve the message from a HubSpot response.
+	 *
+	 * @param array $response_body Response payload.
+	 * @param int   $response_code Response code.
+	 * @return string
+	 */
+	public static function wps_wgm_get_hubspot_response_message( $response_body, $response_code ) {
+		$response_body = is_array( $response_body ) ? $response_body : array();
+		$message       = '';
+
+		if ( ! empty( $response_body['inlineMessage'] ) ) {
+			$message = self::wps_wgm_clean_response_message( $response_body['inlineMessage'] );
+		} elseif ( ! empty( $response_body['errors'][0]['message'] ) ) {
+			$message = self::wps_wgm_clean_response_message( $response_body['errors'][0]['message'] );
+		} elseif ( ! empty( $response_body['message'] ) ) {
+			$message = self::wps_wgm_clean_response_message( $response_body['message'] );
+		}
+
+		if ( '' !== $message ) {
+			return $message;
+		}
+
+		if ( $response_code >= 200 && $response_code < 300 ) {
+			return esc_html__( 'Thank you for submitting your request.', 'woo-gift-cards-lite' );
+		}
+
+		return esc_html__( 'We could not submit your request right now. Please try again.', 'woo-gift-cards-lite' );
+	}
+
+	/**
+	 * Get the store currency code when available.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_store_currency() {
+		return function_exists( 'get_woocommerce_currency' ) ? (string) get_woocommerce_currency() : '';
+	}
+
+	/**
+	 * Get the store country label when available.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_store_country_label() {
+		$default_country = function_exists( 'get_option' ) ? (string) get_option( 'woocommerce_default_country', '' ) : '';
+		$country_code    = strtok( $default_country, ':' );
+		$country_code    = is_string( $country_code ) ? strtoupper( $country_code ) : '';
+
+		if ( '' === $country_code ) {
+			return '';
+		}
+
+		if ( function_exists( 'WC' ) ) {
+			$wc_instance = WC();
+			if ( ! empty( $wc_instance->countries ) && ! empty( $wc_instance->countries->countries[ $country_code ] ) ) {
+				return (string) $wc_instance->countries->countries[ $country_code ];
+			}
+		}
+
+		return $country_code;
+	}
+
+	/**
+	 * Get the last twelve months of paid-order revenue.
+	 *
+	 * @return string
+	 */
+	public static function wps_wgm_get_annual_revenue_last_12_months() {
+		global $wpdb;
+
+		$amount          = null;
+		$fallback_amount = null;
+
+		if ( isset( $wpdb ) && is_object( $wpdb ) && ! empty( $wpdb->prefix ) ) {
+			$table_name = $wpdb->prefix . 'wc_order_stats';
+
+			if ( self::wps_wgm_order_stats_table_exists( $wpdb, $table_name ) ) {
+				$amount = self::wps_wgm_get_revenue_from_order_stats_table( $wpdb, $table_name );
+			}
+		}
+
+		if ( null === $amount || (float) $amount <= 0 ) {
+			$fallback_amount = self::wps_wgm_get_revenue_from_wc_orders();
+
+			if ( null === $amount || (float) $fallback_amount > 0 ) {
+				$amount = $fallback_amount;
+			}
+		}
+
+		if ( null === $amount ) {
+			$amount = 0;
+		}
+
+		return number_format( (float) $amount, 2, '.', '' );
+	}
+
+	/**
+	 * Check whether the WooCommerce analytics table exists.
+	 *
+	 * @param object $wpdb WordPress database object.
+	 * @param string $table_name Table name.
+	 * @return bool
+	 */
+	public static function wps_wgm_order_stats_table_exists( $wpdb, $table_name ) {
+		if ( ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+			return false;
+		}
+
+		$query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name );
+
+		return $table_name === (string) $wpdb->get_var( $query );
+	}
+
+	/**
+	 * Get revenue using WooCommerce analytics order stats.
+	 *
+	 * @param object $wpdb WordPress database object.
+	 * @param string $table_name Table name.
+	 * @return float
+	 */
+	public static function wps_wgm_get_revenue_from_order_stats_table( $wpdb, $table_name ) {
+		if ( ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+			return 0.0;
+		}
+
+		$paid_statuses = self::wps_wgm_get_paid_status_values();
+		$placeholders  = implode( ', ', array_fill( 0, count( $paid_statuses ), '%s' ) );
+		$start_date    = gmdate( 'Y-m-d H:i:s', strtotime( '-12 months' ) );
+		$sql           = "SELECT COALESCE(SUM(total_sales), 0) FROM {$table_name} WHERE parent_id = 0 AND date_paid IS NOT NULL AND date_paid >= %s AND status IN ({$placeholders})";
+		$args          = array_merge( array( $sql, $start_date ), $paid_statuses );
+		$query         = call_user_func_array( array( $wpdb, 'prepare' ), $args );
+
+		return (float) $wpdb->get_var( $query );
+	}
+
+	/**
+	 * Get revenue using wc_get_orders when the analytics table is unavailable.
+	 *
+	 * @return float
+	 */
+	public static function wps_wgm_get_revenue_from_wc_orders() {
+		if ( ! function_exists( 'wc_get_orders' ) ) {
+			return 0.0;
+		}
+
+		$cutoff_timestamp = strtotime( '-12 months', current_time( 'timestamp', true ) );
+		$orders           = wc_get_orders(
+			array(
+				'limit'   => -1,
+				'status'  => function_exists( 'wc_get_is_paid_statuses' ) ? wc_get_is_paid_statuses() : array( 'processing', 'completed' ),
+				'type'    => 'shop_order',
+				'parent'  => 0,
+				'return'  => 'objects',
+				'orderby' => 'date',
+				'order'   => 'DESC',
+			)
+		);
+
+		$total = 0.0;
+
+		foreach ( (array) $orders as $order ) {
+			if ( ! is_object( $order ) ) {
+				continue;
+			}
+
+			if ( ! method_exists( $order, 'get_date_paid' ) || ! $order->get_date_paid() ) {
+				continue;
+			}
+
+			if ( method_exists( $order, 'get_parent_id' ) && (int) $order->get_parent_id() > 0 ) {
+				continue;
+			}
+
+			$date_paid = $order->get_date_paid();
+			if ( ! $date_paid || ! method_exists( $date_paid, 'getTimestamp' ) || $date_paid->getTimestamp() < $cutoff_timestamp ) {
+				continue;
+			}
+
+			if ( method_exists( $order, 'get_total' ) ) {
+				$total += (float) $order->get_total();
+			}
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Get both prefixed and unprefixed paid statuses for analytics queries.
+	 *
+	 * @return array
+	 */
+	public static function wps_wgm_get_paid_status_values() {
+		$statuses = function_exists( 'wc_get_is_paid_statuses' ) ? (array) wc_get_is_paid_statuses() : array( 'processing', 'completed' );
+		$values   = array();
+
+		foreach ( $statuses as $status ) {
+			$status = strtolower( preg_replace( '/[^a-z0-9_-]/i', '', (string) $status ) );
+
+			if ( '' === $status ) {
+				continue;
+			}
+
+			$values[] = $status;
+
+			if ( 0 === strpos( $status, 'wc-' ) ) {
+				$values[] = substr( $status, 3 );
+			} else {
+				$values[] = 'wc-' . $status;
+			}
+		}
+
+		return array_values( array_unique( $values ) );
+	}
+}

--- a/includes/class-woocommerce-gift-cards-lite.php
+++ b/includes/class-woocommerce-gift-cards-lite.php
@@ -122,6 +122,11 @@ class Woocommerce_Gift_Cards_Lite {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-woocommerce-gift-cards-lite-admin.php';
 
 		/**
+		 * The class responsible for handling the admin Talk to an Expert form.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php';
+
+		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
@@ -161,7 +166,8 @@ class Woocommerce_Gift_Cards_Lite {
 	 */
 	private function define_admin_hooks() {
 
-		$plugin_admin = new Woocommerce_Gift_Cards_Lite_Admin( $this->get_plugin_name(), $this->get_version() );
+		$plugin_admin   = new Woocommerce_Gift_Cards_Lite_Admin( $this->get_plugin_name(), $this->get_version() );
+		$talk_to_expert = new Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form();
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'wps_wgm_enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'wps_wgm_enqueue_scripts' );
@@ -192,6 +198,7 @@ class Woocommerce_Gift_Cards_Lite {
 		$this->loader->add_action( 'admin_notices', $plugin_admin, 'wps_wgm_display_notification_bar' );
 		$this->loader->add_action( 'wp_ajax_wps_wgm_dismiss_notice', $plugin_admin, 'wps_wgm_dismiss_notice' );
 		$this->loader->add_action( 'wp_ajax_wps_wgm_dismiss_notice_banner', $plugin_admin, 'wps_wgm_dismiss_notice_banner' );
+		$this->loader->add_action( 'wp_ajax_' . Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form::AJAX_ACTION, $talk_to_expert, 'wps_wgm_handle_ajax_submission' );
 		// Add your screen.
 		$this->loader->add_filter( 'wps_helper_valid_frontend_screens', $plugin_admin, 'add_wps_frontend_screens' );
 		// Add Deactivation screen.

--- a/includes/class-woocommerce-gift-cards-lite.php
+++ b/includes/class-woocommerce-gift-cards-lite.php
@@ -369,10 +369,13 @@ class Woocommerce_Gift_Cards_Lite {
 	 */
 	public function wps_wgm_is_par_active() {
 
+		static $flag = null;
+		if ( null !== $flag ) {
+			return $flag;
+		}
 		$flag           = false;
 		$active_plugins = (array) get_option( 'active_plugins', array() );
 		if ( in_array( 'points-and-rewards-for-woocommerce/points-rewards-for-woocommerce.php', $active_plugins ) ) {
-
 			$flag = true;
 		}
 		return $flag;
@@ -385,12 +388,15 @@ class Woocommerce_Gift_Cards_Lite {
 	 */
 	public function wps_wgm_is_par_enable() {
 
+		static $flag = null;
+		if ( null !== $flag ) {
+			return $flag;
+		}
 		$flag             = false;
 		$general_settings = get_option( 'wps_wpr_settings_gallery', true );
 		$general_settings = ! empty( $general_settings ) && is_array( $general_settings ) ? $general_settings : array();
 		$wps_wpr_enable   = ! empty( $general_settings['wps_wpr_general_setting_enable'] ) ? $general_settings['wps_wpr_general_setting_enable'] : 0;
 		if ( '1' == $wps_wpr_enable ) {
-
 			$flag = true;
 		}
 		return $flag;

--- a/public/class-woocommerce-gift-cards-lite-public.php
+++ b/public/class-woocommerce-gift-cards-lite-public.php
@@ -86,6 +86,10 @@ class Woocommerce_Gift_Cards_Lite_Public {
 		 * class.
 		 */
 
+		if ( ! $this->wps_wgm_should_enqueue_frontend_assets() ) {
+			return;
+		}
+
 		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/woocommerce_gift_cards_lite-public.css', array(), $this->version, 'all' );
 		wp_enqueue_style( 'thickbox' );
 		$other_settings = get_option( 'wps_wgm_other_settings', array() );
@@ -95,6 +99,49 @@ class Woocommerce_Gift_Cards_Lite_Public {
 
 			wp_enqueue_style( $this->plugin_name . 'single-page', plugin_dir_url( __FILE__ ) . 'css/woocommerce_gift_cards_lite-single-page.css', array(), $this->version, 'all' );
 		}
+	}
+
+	/**
+	 * Check whether current frontend view needs gift card assets.
+	 *
+	 * @return bool
+	 */
+	private function wps_wgm_should_enqueue_frontend_assets() {
+		$other_settings        = get_option( 'wps_wgm_other_settings', array() );
+		$wps_wgm_gc_custom_page = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_render_product_custom_page' );
+
+		global $post;
+		$post_id      = isset( $post->ID ) ? $post->ID : '';
+		$page_content = '';
+		if ( ! empty( $post_id ) ) {
+			$page         = get_post( $post->ID );
+			$page_content = ! empty( $page->post_content ) ? $page->post_content : '';
+		}
+
+		if ( str_contains( $page_content, 'wps_check_your_gift_card_balance' ) || ( function_exists( 'is_account_page' ) && is_account_page() ) ) {
+			return true;
+		}
+
+		if ( ! is_product() && ! ( str_contains( $page_content, 'product_page id' ) && 'on' == $wps_wgm_gc_custom_page ) ) {
+			return (bool) apply_filters( 'wps_wgm_load_product_script', false );
+		}
+
+		if ( str_contains( $page_content, 'product_page id' ) ) {
+			$content = $post->post_content;
+			if ( isset( ( explode( '=', explode( ']', $content )[0] ) )[1] ) ) {
+				$array      = ( explode( '=', explode( ']', $content )[0] ) )[1];
+				$product_id = intval( explode( '"', $array )[1] );
+			} else {
+				$product_id = $post->ID;
+			}
+		} else {
+			$product_id = $post->ID;
+		}
+
+		$product_type       = WC_Product_Factory::get_product_type( $product_id );
+		$sell_as_a_giftcard = get_post_meta( $product_id, '_sell_as_a_giftcard' );
+
+		return 'wgm_gift_card' === $product_type || ( isset( $sell_as_a_giftcard[0] ) && 'yes' === $sell_as_a_giftcard[0] );
 	}
 
 	/**

--- a/public/class-woocommerce-gift-cards-lite-public.php
+++ b/public/class-woocommerce-gift-cards-lite-public.php
@@ -173,14 +173,12 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			} else {
 				$product_id    = $post->ID;
 			}
-			$product_types = wp_get_object_terms( $product_id, 'product_type' );
-			if ( isset( $product_types[0] ) ) {
-				$product_type       = $product_types[0]->slug;
-				$sell_as_a_giftcard = get_post_meta( $product_id, '_sell_as_a_giftcard' );
-				if ( 'wgm_gift_card' === $product_type || ( isset( $sell_as_a_giftcard[0] ) && 'yes' === $sell_as_a_giftcard[0] ) ) {
+			$product_type       = WC_Product_Factory::get_product_type( $product_id );
+			$sell_as_a_giftcard = get_post_meta( $product_id, '_sell_as_a_giftcard' );
+			if ( 'wgm_gift_card' === $product_type || ( isset( $sell_as_a_giftcard[0] ) && 'yes' === $sell_as_a_giftcard[0] ) ) {
 					// for price based on country.
+					$wps_wgm_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
 					if ( class_exists( 'WCPBC_Pricing_Zone' ) ) {
-						$wps_wgm_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
 						if ( wcpbc_the_zone() !== null && wcpbc_the_zone() ) {
 							if ( isset( $wps_wgm_pricing['type'] ) ) {
 								$product_pricing_type = $wps_wgm_pricing['type'];
@@ -195,7 +193,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							}
 						}
 					} elseif ( function_exists( 'wps_mmcsfw_admin_fetch_currency_rates_from_base_currency' ) ) {
-						$wps_wgm_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
 						if ( isset( $wps_wgm_pricing['type'] ) ) {
 							$product_pricing_type = $wps_wgm_pricing['type'];
 							if ( 'wps_wgm_range_price' === $product_pricing_type ) {
@@ -208,18 +205,16 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							}
 						}
 					} elseif ( class_exists( 'WCML_Multi_Currency_Prices' ) && is_plugin_active( 'gc-addon/gc-addon.php' ) ) {
-						$wps_wgm_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
-						$wps_wgm_pricing = apply_filters( 'wps_wgm_pricing_wcml', $wps_wgm_pricing );
-						$is_customizable = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
-						$genaral_settings = get_option( 'wps_wgm_general_settings', array() );
+						$wps_wgm_pricing         = apply_filters( 'wps_wgm_pricing_wcml', $wps_wgm_pricing );
+						$is_customizable         = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
+						$genaral_settings        = get_option( 'wps_wgm_general_settings', array() );
 						$enable_sent_multiple_gc = $this->wps_common_fun->wps_wgm_get_template_data( $genaral_settings, 'wps_wgm_general_setting_enable_sent_multiple_giftcard' );
-						$is_imported_product = get_post_meta( $product_id, 'is_imported', true );
+						$is_imported_product     = get_post_meta( $product_id, 'is_imported', true );
 					} else {
-						$wps_wgm_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
-						$is_customizable = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
-						$genaral_settings = get_option( 'wps_wgm_general_settings', array() );
+						$is_customizable         = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
+						$genaral_settings        = get_option( 'wps_wgm_general_settings', array() );
 						$enable_sent_multiple_gc = $this->wps_common_fun->wps_wgm_get_template_data( $genaral_settings, 'wps_wgm_general_setting_enable_sent_multiple_giftcard' );
-						$is_imported_product = get_post_meta( $product_id, 'is_imported', true );
+						$is_imported_product     = get_post_meta( $product_id, 'is_imported', true );
 					}
 
 					$wps_wgm['pricing_type'] = $wps_wgm_pricing;
@@ -234,7 +229,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 					wp_localize_script( $this->plugin_name, 'wps_wgm', $wps_wgm );
 					wp_enqueue_script( $this->plugin_name );
 				}
-			}
 		}
 
 		if ( str_contains( $page_content, 'wps_check_your_gift_card_balance' ) || ( function_exists( 'is_account_page' ) && is_account_page() ) ) {
@@ -278,12 +272,7 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			$product_id = $wps_product;
 		}
 
-		$product_types = wp_get_object_terms( $product_id, 'product_type' );
-		if ( ! empty( $product_types ) ) {
-			$product_type  = $product_types[0]->slug;
-		} else {
-			$product_type = '';
-		}
+		$product_type = WC_Product_Factory::get_product_type( $product_id ) ?: '';
 
 		if ( 'wgm_gift_card' === $product_type ) {
 			$wps_cart_html = $this->wps_wgm_before_cart_data( $wps_product );
@@ -317,17 +306,17 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			if ( $wps_wgc_enable ) {
 				$product_id = $product->get_id();
 				if ( isset( $product_id ) && ! empty( $product_id ) ) {
-					$product_types = wp_get_object_terms( $product_id, 'product_type' );
-					$product_type  = $product_types[0]->slug;
+					$product_type = $product->get_type();
 					if ( 'wgm_gift_card' === $product_type ) {
 						$cart_html              = '';
 						$wps_additional_section = '';
 						$product_pricing        = get_post_meta( $product_id, 'wps_wgm_pricing', true );
 						if ( isset( $product_pricing ) && ! empty( $product_pricing ) ) {
 
-							$other_settings = get_option( 'wps_wgm_other_settings', array() );
+							$other_settings = wps_wgm_get_plugin_option( 'wps_wgm_other_settings' );
 
-							$use_new_page_layout = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_new_gift_card_page_layout' );
+							$use_new_page_layout     = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_new_gift_card_page_layout' );
+							$wps_wgm_preview_disable = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_additional_preview_disable' );
 							if ( 'on' == $use_new_page_layout ) {
 								$cart_html .= '<div class="wps_wgm_added_wrapper wps-gc_lay-2">';
 							} else {
@@ -533,18 +522,13 @@ class Woocommerce_Gift_Cards_Lite_Public {
 								$cart_html .= apply_filters( 'wps_wgm_add_price_types', $wps_additional_section, $product, $product_pricing );
 							}
 							// new layout setting ///////////////////////////////.
-							$other_settings = get_option( 'wps_wgm_other_settings', array() );
-							$use_new_page_layout = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_new_gift_card_page_layout' );
-
 							if ( 'on' == $use_new_page_layout ) {
-								if ( '' !== apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id ) ) {
-									$cart_html .= apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id )['html'];
-									$choosed_temp = apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id )['choosen_temp_id'];
+								$wps_display_thumbnail = apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id );
+								if ( '' !== $wps_display_thumbnail ) {
+									$cart_html    .= $wps_display_thumbnail['html'];
+									$choosed_temp  = $wps_display_thumbnail['choosen_temp_id'];
 								}
 							}
-							// new layout setting ///////////////////////////////.
-							$other_settings = get_option( 'wps_wgm_other_settings', array() );
-							$wps_wgm_preview_disable = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_additional_preview_disable' );
 
 							if ( '' == $use_new_page_layout ) {
 								$cart_html .= apply_filters( 'wps_wgm_select_date', $wps_additional_section, $product_id );
@@ -659,9 +643,10 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							// old layout setting //////////////////////////////////////.
 
 							if ( '' == $use_new_page_layout ) {
-								if ( '' !== apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id ) ) {
-									$cart_html .= apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id )['html'];
-									$choosed_temp = apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id )['choosen_temp_id'];
+								$wps_display_thumbnail = apply_filters( 'wps_wgm_display_thumbnail', $wps_additional_section, $product_id );
+								if ( '' !== $wps_display_thumbnail ) {
+									$cart_html   .= $wps_display_thumbnail['html'];
+									$choosed_temp = $wps_display_thumbnail['choosen_temp_id'];
 								}
 							}
 							// old layout setting //////////////////////////////////////.
@@ -669,8 +654,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							if ( is_array( $templateid ) && ! empty( $templateid ) ) {
 								$cart_html .= '<input name="wps_wgm_selected_temp" id="wps_wgm_selected_temp" value="' . $choosed_temp . '" type="hidden">';
 							}
-							$other_settings = get_option( 'wps_wgm_other_settings', array() );
-							$wps_wgm_preview_disable = $this->wps_common_fun->wps_wgm_get_template_data( $other_settings, 'wps_wgm_additional_preview_disable' );
 
 							if ( empty( $wps_wgm_preview_disable ) ) {
 								$cart_html .= '<span class="mwg_wgm_preview_email"><a id="mwg_wgm_preview_email">' . __( 'PREVIEW', 'woo-gift-cards-lite' ) . '</a></span>';
@@ -702,19 +685,18 @@ class Woocommerce_Gift_Cards_Lite_Public {
 		$wps_wgc_enable = wps_wgm_giftcard_enable();
 
 		if ( $wps_wgc_enable ) {
-			$product_types = wp_get_object_terms( $product_id, 'product_type' );
-			if ( isset( $product_types[0] ) ) {
-				$product_type = $product_types[0]->slug;
-				if ( 'wgm_gift_card' === $product_type || ( isset( $_POST['wps_gift_this_product'] ) && 'on' === $_POST['wps_gift_this_product'] ) ) {
+			$product_type = WC_Product_Factory::get_product_type( $product_id );
+			if ( 'wgm_gift_card' === $product_type || ( isset( $_POST['wps_gift_this_product'] ) && 'on' === $_POST['wps_gift_this_product'] ) ) {
 					$wps_field_nonce = isset( $_POST['wps_wgm_single_nonce_field'] ) ? stripcslashes( sanitize_text_field( wp_unslash( $_POST['wps_wgm_single_nonce_field'] ) ) ) : '';
 					if ( ! wp_verify_nonce( $wps_field_nonce, 'wps_wgm_single_nonce' ) ) {
 						echo '';
 					} else {
 
 						// for price based on country.
+						$_pricing_raw    = get_post_meta( $product_id, 'wps_wgm_pricing', true );
+						$product_pricing = ! empty( $_pricing_raw ) ? $_pricing_raw : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 						if ( class_exists( 'WCPBC_Pricing_Zone' ) ) {
 							if ( wcpbc_the_zone() != null && wcpbc_the_zone() ) {
-								$product_pricing      = ! empty( get_post_meta( $product_id, 'wps_wgm_pricing', true ) ) ? get_post_meta( $product_id, 'wps_wgm_pricing', true ) : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 								$product_pricing_type = $product_pricing['type'];
 								if ( isset( $_POST['wps_wgm_price'] ) && ! empty( $_POST['wps_wgm_price'] ) ) {
 									if ( 'wps_wgm_range_price' == $product_pricing_type || 'wps_wgm_user_price' == $product_pricing_type ) {
@@ -725,7 +707,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 								}
 							}
 						} elseif ( function_exists( 'wps_mmcsfw_admin_fetch_currency_rates_to_base_currency' ) ) {
-							$product_pricing      = ! empty( get_post_meta( $product_id, 'wps_wgm_pricing', true ) ) ? get_post_meta( $product_id, 'wps_wgm_pricing', true ) : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 							$product_pricing_type = $product_pricing['type'];
 							$is_customizable      = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
 							if ( isset( $_POST['wps_wgm_price'] ) && ! empty( $_POST['wps_wgm_price'] ) ) {
@@ -740,7 +721,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							$is_customizable        = get_post_meta( $product_id, 'woocommerce_customizable_giftware', true );
 						}
 						if ( isset( $_POST['wps_wgm_send_giftcard'] ) && ! empty( $_POST['wps_wgm_send_giftcard'] ) ) {
-							$product_pricing = ! empty( get_post_meta( $product_id, 'wps_wgm_pricing', true ) ) ? get_post_meta( $product_id, 'wps_wgm_pricing', true ) : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 							if ( isset( $product_pricing ) && ! empty( $product_pricing ) ) {
 
 								if ( isset( $_POST['wps_wgm_to_email'] ) && ! empty( $_POST['wps_wgm_to_email'] ) ) {
@@ -808,7 +788,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 					}
 				}
 			}
-		}
 		if ( get_option( 'wps_gccoupon_rechargeable_product_id' ) == $product_id ) {
 			$recharge_code = WC()->session->get( 'gc_recharge_code' );
 			$item_meta['recharge_coupon_key_field'] = $recharge_code;
@@ -842,16 +821,13 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			return false;
 		}
 
-		$product_types = wp_get_object_terms( $product_id, 'product_type' );
+		$product_type = WC_Product_Factory::get_product_type( $product_id );
 
-		if ( isset( $product_types[0] ) ) {
-			$product_type = $product_types[0]->slug;
-			if ( 'wgm_gift_card' === $product_type || ( isset( $_POST['wps_gift_this_product'] ) && 'on' === $_POST['wps_gift_this_product'] ) ) {
-				$wps_field_nonce = isset( $_POST['wps_wgm_single_nonce_field'] ) ? stripcslashes( sanitize_text_field( wp_unslash( $_POST['wps_wgm_single_nonce_field'] ) ) ) : '';
-				if ( ! wp_verify_nonce( $wps_field_nonce, 'wps_wgm_single_nonce' ) ) {
-					throw new Exception( esc_html__( 'Sorry, your nonce not verify. Please try again !', 'woo-gift-cards-lite' ) );
+		if ( 'wgm_gift_card' === $product_type || ( isset( $_POST['wps_gift_this_product'] ) && 'on' === $_POST['wps_gift_this_product'] ) ) {
+			$wps_field_nonce = isset( $_POST['wps_wgm_single_nonce_field'] ) ? stripcslashes( sanitize_text_field( wp_unslash( $_POST['wps_wgm_single_nonce_field'] ) ) ) : '';
+			if ( ! wp_verify_nonce( $wps_field_nonce, 'wps_wgm_single_nonce' ) ) {
+				throw new Exception( esc_html__( 'Sorry, your nonce not verify. Please try again !', 'woo-gift-cards-lite' ) );
 
-				}
 			}
 		}
 	}
@@ -986,13 +962,12 @@ class Woocommerce_Gift_Cards_Lite_Public {
 	public function wps_wgm_woocommerce_get_price_html( $price_html, $product ) {
 		$wps_wgc_enable = wps_wgm_giftcard_enable();
 		if ( $wps_wgc_enable ) {
-			$product_id = $product->get_id();
+			$product_id   = $product->get_id();
+			$product_type = $product->get_type();
 			if ( isset( $product_id ) ) {
-				$product_types = wp_get_object_terms( $product_id, 'product_type' );
-				if ( isset( $product_types[0] ) ) {
-					$product_type = $product_types[0]->slug;
-					if ( 'wgm_gift_card' == $product_type ) {
-						$product_pricing = ! empty( get_post_meta( $product_id, 'wps_wgm_pricing', true ) ) ? get_post_meta( $product_id, 'wps_wgm_pricing', true ) : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
+				if ( 'wgm_gift_card' == $product_type ) {
+						$_pricing_raw    = get_post_meta( $product_id, 'wps_wgm_pricing', true );
+						$product_pricing = ! empty( $_pricing_raw ) ? $_pricing_raw : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 						if ( isset( $product_pricing ) && ! empty( $product_pricing ) ) {
 							if ( isset( $product_pricing['type'] ) ) {
 								$product_pricing_type = $product_pricing['type'];
@@ -1181,7 +1156,6 @@ class Woocommerce_Gift_Cards_Lite_Public {
 						}
 						$price_html = apply_filters( 'wps_wgm_pricing_html', $price_html, $product, $product_pricing );
 					}
-				}
 			}
 		}
 		$product_id_to_hide = get_option( 'contributor_product_id' ); // Replace with your actual product ID.
@@ -1708,23 +1682,12 @@ class Woocommerce_Gift_Cards_Lite_Public {
 	public function wps_wgm_woocommerce_loop_add_to_cart_link( $link, $product ) {
 		$wps_wgc_enable = wps_wgm_giftcard_enable();
 		if ( $wps_wgc_enable ) {
-			$product_id = $product->get_id();
+			$product_id   = $product->get_id();
+			$product_type = $product->get_type();
 			if ( isset( $product_id ) ) {
-				$product_types = wp_get_object_terms( $product_id, 'product_type' );
-				if ( isset( $product_types[0] ) ) {
-					$product_type = $product_types[0]->slug;
-					if ( 'wgm_gift_card' == $product_type ) {
-						$product_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
-						if ( isset( $product_pricing ) && ! empty( $product_pricing ) ) {
-							$link = sprintf(
-								'<a rel="nofollow" href="%s" class="%s">%s</a>',
-								esc_url( get_the_permalink() ),
-								esc_attr( isset( $class ) ? $class : 'button wps_gc_button' ),
-								esc_html( apply_filters( 'wps_wgm_view_card_text', __( 'VIEW CARD', 'woo-gift-cards-lite' ) ) )
-							);
-						}
-						$link = apply_filters( 'wps_wgm_loop_add_to_cart_link', $link, $product );
-					} elseif ( get_option( 'gc_expiry_extension_product_id' ) == $product_id ) {
+				if ( 'wgm_gift_card' == $product_type ) {
+					$product_pricing = get_post_meta( $product_id, 'wps_wgm_pricing', true );
+					if ( isset( $product_pricing ) && ! empty( $product_pricing ) ) {
 						$link = sprintf(
 							'<a rel="nofollow" href="%s" class="%s">%s</a>',
 							esc_url( get_the_permalink() ),
@@ -1732,6 +1695,14 @@ class Woocommerce_Gift_Cards_Lite_Public {
 							esc_html( apply_filters( 'wps_wgm_view_card_text', __( 'VIEW CARD', 'woo-gift-cards-lite' ) ) )
 						);
 					}
+					$link = apply_filters( 'wps_wgm_loop_add_to_cart_link', $link, $product );
+				} elseif ( get_option( 'gc_expiry_extension_product_id' ) == $product_id ) {
+					$link = sprintf(
+						'<a rel="nofollow" href="%s" class="%s">%s</a>',
+						esc_url( get_the_permalink() ),
+						esc_attr( isset( $class ) ? $class : 'button wps_gc_button' ),
+						esc_html( apply_filters( 'wps_wgm_view_card_text', __( 'VIEW CARD', 'woo-gift-cards-lite' ) ) )
+					);
 				}
 			}
 		}
@@ -1758,13 +1729,10 @@ class Woocommerce_Gift_Cards_Lite_Public {
 				$giftcard_tax_cal_enable = 'off';
 			}
 			if ( 'off' == $giftcard_tax_cal_enable ) {
-				$product_id = $product->get_id();
-				$product_types = wp_get_object_terms( $product_id, 'product_type' );
-				if ( isset( $product_types[0] ) ) {
-					$product_type = $product_types[0]->slug;
-					if ( 'wgm_gift_card' == $product_type ) {
-						$taxable = false;
-					}
+				$product_id   = $product->get_id();
+				$product_type = $product->get_type();
+				if ( 'wgm_gift_card' == $product_type ) {
+					$taxable = false;
 				}
 			}
 		}
@@ -1782,16 +1750,13 @@ class Woocommerce_Gift_Cards_Lite_Public {
 	public function wps_wgm_woocommerce_before_main_content() {
 		global $post;
 		if ( isset( $post->ID ) ) {
-			$product_id = $post->ID;
-			$product_types = wp_get_object_terms( $product_id, 'product_type' );
+			$product_id         = $post->ID;
+			$product_type       = WC_Product_Factory::get_product_type( $product_id );
 			$sell_as_a_giftcard = get_post_meta( $product_id, '_sell_as_a_giftcard' );
-			if ( isset( $product_types[0] ) ) {
-				$product_type = $product_types[0]->slug;
-				if ( 'wgm_gift_card' === $product_type || ( isset( $sell_as_a_giftcard[0] ) && 'yes' === $sell_as_a_giftcard[0] ) ) {
-					?>
-					<div class="woocommerce-error" id="wps_wgm_error_notice" style="display:none;"></div>
-					<?php
-				}
+			if ( 'wgm_gift_card' === $product_type || ( isset( $sell_as_a_giftcard[0] ) && 'yes' === $sell_as_a_giftcard[0] ) ) {
+				?>
+				<div class="woocommerce-error" id="wps_wgm_error_notice" style="display:none;"></div>
+				<?php
 			}
 		}
 	}
@@ -1827,13 +1792,10 @@ class Woocommerce_Gift_Cards_Lite_Public {
 						while ( $loop->have_posts() ) :
 							$loop->the_post();
 							global $product;
-							$product_id = $loop->post->ID;
-							$product_types = wp_get_object_terms( $product_id, 'product_type' );
-							if ( isset( $product_types[0] ) ) {
-								$product_type = $product_types[0]->slug;
-								if ( 'wgm_gift_card' == $product_type ) {
-									$gift_products[] = $product_id;
-								}
+							$product_id   = $loop->post->ID;
+							$product_type = WC_Product_Factory::get_product_type( $product_id );
+							if ( 'wgm_gift_card' == $product_type ) {
+								$gift_products[] = $product_id;
 							}
 						endwhile;
 					endif;
@@ -1934,25 +1896,22 @@ class Woocommerce_Gift_Cards_Lite_Public {
 	
 							$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 							$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
-							$product_types = wp_get_object_terms( $product_id, 'product_type' );
-							if ( isset( $product_types[0] ) ) {
-								$product_type = $product_types[0]->slug;
-								if ( isset( $cart_item['product_meta'] ) ) {
-									if ( 'wgm_gift_card' == $product_type || ( isset( $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) && 'on' === $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) ) {
-										if ( 'Mail to recipient' == $cart_item['product_meta']['meta_data']['delivery_method'] || 'Downloadable' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
-											$gift_bool = true;
-										} elseif ( 'shipping' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
-											$gift_bool_ship = true;
-										}
-									} else if ( ! $cart_item['data']->is_virtual() ) {
-										$other_bool = true;
+							$product_type = $_product->get_type();
+							if ( isset( $cart_item['product_meta'] ) ) {
+								if ( 'wgm_gift_card' == $product_type || ( isset( $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) && 'on' === $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) ) {
+									if ( 'Mail to recipient' == $cart_item['product_meta']['meta_data']['delivery_method'] || 'Downloadable' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
+										$gift_bool = true;
+									} elseif ( 'shipping' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
+										$gift_bool_ship = true;
 									}
 								} else if ( ! $cart_item['data']->is_virtual() ) {
 									$other_bool = true;
 								}
+							} else if ( ! $cart_item['data']->is_virtual() ) {
+								$other_bool = true;
 							}
 						}
-	
+
 						if ( $gift_bool && ! $gift_bool_ship && ! $other_bool ) {
 							$enable = false;
 						} else {
@@ -1972,22 +1931,19 @@ class Woocommerce_Gift_Cards_Lite_Public {
 						foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 							$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 							$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
-							$product_types = wp_get_object_terms( $product_id, 'product_type' );
-							if ( isset( $product_types[0] ) ) {
-								$product_type = $product_types[0]->slug;
-								if ( isset( $cart_item['product_meta'] ) ) {
-									if ( 'wgm_gift_card' == $product_type || ( isset( $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) && 'on' === $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) ) {
-										if ( 'Mail to recipient' == $cart_item['product_meta']['meta_data']['delivery_method'] || 'Downloadable' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
-											$gift_bool = true;
-										} elseif ( 'shipping' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
-											$gift_bool_ship = true;
-										}
-									} else if ( ! $cart_item['data']->is_virtual() ) {
-										$other_bool = true;
+							$product_type = $_product->get_type();
+							if ( isset( $cart_item['product_meta'] ) ) {
+								if ( 'wgm_gift_card' == $product_type || ( isset( $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) && 'on' === $cart_item['product_meta']['meta_data']['sell_as_a_gc'] ) ) {
+									if ( 'Mail to recipient' == $cart_item['product_meta']['meta_data']['delivery_method'] || 'Downloadable' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
+										$gift_bool = true;
+									} elseif ( 'shipping' == $cart_item['product_meta']['meta_data']['delivery_method'] ) {
+										$gift_bool_ship = true;
 									}
 								} else if ( ! $cart_item['data']->is_virtual() ) {
 									$other_bool = true;
 								}
+							} else if ( ! $cart_item['data']->is_virtual() ) {
+								$other_bool = true;
 							}
 						}
 						if ( $gift_bool && ! $gift_bool_ship && ! $other_bool ) {
@@ -2041,7 +1997,8 @@ class Woocommerce_Gift_Cards_Lite_Public {
 		if ( isset( $_GET['wps_wgc_preview_email'] ) && 'wps_wgm_single_page_popup' == $_GET['wps_wgc_preview_email'] ) {
 
 			$product_id                     = isset( $_GET['product_id'] ) ? sanitize_text_field( wp_unslash( $_GET['product_id'] ) ) : '';
-			$product_pricing                = ! empty( get_post_meta( $product_id, 'wps_wgm_pricing', true ) ) ? get_post_meta( $product_id, 'wps_wgm_pricing', true ) : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
+			$_pricing_raw                   = get_post_meta( $product_id, 'wps_wgm_pricing', true );
+			$product_pricing                = ! empty( $_pricing_raw ) ? $_pricing_raw : get_post_meta( $product_id, 'wps_wgm_pricing_details', true );
 			$product_pricing_type           = $product_pricing['type'];
 			$general_setting                = get_option( 'wps_wgm_general_settings', array() );
 			$giftcard_coupon_length_display = $this->wps_common_fun->wps_wgm_get_template_data( $general_setting, 'wps_wgm_general_setting_giftcard_coupon_length' );
@@ -2998,7 +2955,7 @@ class Woocommerce_Gift_Cards_Lite_Public {
 	 * @throws Exception If the daily redemption limit is exceeded.
 	 */
 	public function wps_wgm_validate_daily_redemption_limit( $is_valid, $coupon ) {
-		$general_settings = get_option( 'wps_wgm_general_settings', array() );
+		$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
 		$limit = $this->wps_common_fun->wps_wgm_get_template_data( $general_settings, 'wps_wgm_general_setting_daily_redemption_limit' );
 		$limit = is_numeric( $limit ) ? absint( $limit ) : 0;
 		$limit = (int) apply_filters( 'wps_wgm_daily_redemption_limit', $limit, $coupon );

--- a/woocommerce_gift_cards_lite.php
+++ b/woocommerce_gift_cards_lite.php
@@ -147,19 +147,38 @@ if ( $activated ) {
 		 * @link https://www.wpswings.com/
 		 */
 		function wps_wgm_giftcard_enable() {
+			static $result = null;
+			if ( null !== $result ) {
+				return $result;
+			}
 			$giftcard_enable = get_option( 'wps_wgm_general_settings', array() );
 			if ( ! empty( $giftcard_enable ) && array_key_exists( 'wps_wgm_general_setting_enable', $giftcard_enable ) ) {
 				$check_enable = $giftcard_enable['wps_wgm_general_setting_enable'];
 				if ( isset( $check_enable ) && ! empty( $check_enable ) ) {
-					if ( 'on' === $check_enable ) {
-						return true;
-					} else {
-						return false;
-					}
+					$result = ( 'on' === $check_enable );
+					return $result;
 				}
 			}
+			$result = false;
+			return $result;
 		}
 	}
+	/**
+	 * Per-request cache wrapper for frequently read plugin options.
+	 * Prevents repeated get_option() calls for the same key within a single request.
+	 *
+	 * @param string $key     Option key.
+	 * @param mixed  $default Default value when option is not set.
+	 * @return mixed
+	 */
+	function wps_wgm_get_plugin_option( $key, $default = array() ) {
+		static $cache = array();
+		if ( ! array_key_exists( $key, $cache ) ) {
+			$cache[ $key ] = get_option( $key, $default );
+		}
+		return $cache[ $key ];
+	}
+
 	register_activation_hook( __FILE__, 'wps_wgm_create_gift_card_taxonomy' );
 
 
@@ -288,7 +307,7 @@ if ( $activated ) {
 				$password .= $final_array[ $key ];
 			}
 
-			$general_settings = get_option( 'wps_wgm_general_settings', array() );
+			$general_settings = wps_wgm_get_plugin_option( 'wps_wgm_general_settings' );
 			if ( ! empty( $general_settings ) && array_key_exists( 'wps_wgm_general_setting_giftcard_prefix', $general_settings ) ) {
 				$giftcard_prefix = $general_settings['wps_wgm_general_setting_giftcard_prefix'];
 			} else {
@@ -319,10 +338,14 @@ if ( $activated ) {
 	 * Schedule the daily reset event at 12:00 AM site time.
 	 */
 	function wps_wgm_schedule_midnight_reset() {
+		if ( get_transient( 'wps_wgm_cron_scheduled' ) ) {
+			return;
+		}
 		if ( ! wp_next_scheduled( 'wps_reset_gifting_request' ) ) {
 			$timestamp = strtotime( 'tomorrow midnight', current_time( 'timestamp' ) );
 			wp_schedule_event( $timestamp, 'daily', 'wps_reset_gifting_request' );
 		}
+		set_transient( 'wps_wgm_cron_scheduled', true, 12 * HOUR_IN_SECONDS );
 	}
 	add_action( 'wp', 'wps_wgm_schedule_midnight_reset' );
 


### PR DESCRIPTION
## Task Link
WPS-6756

## Summary
Performance optimization pass across the plugin plus a new admin "Talk to an Expert" form. Reduced repeated `get_option()` and `wp_get_object_terms()` calls on hot paths, gated admin and frontend asset enqueues to gift-card-relevant screens, cached the dashboard widget summary in a transient, and bumped the plugin version to 3.2.7.

## Changes Made
- Added per-request option cache helper `wps_wgm_get_plugin_option()` and replaced repeated `get_option()` calls in common-function and public classes with it
- Memoized `wps_wgm_is_par_active()`, `wps_wgm_is_par_enable()`, and `wps_wgm_giftcard_enable()` with static flags so subsequent calls in the same request return immediately
- Replaced `wp_get_object_terms( $id, 'product_type' )` lookups with `WC_Product_Factory::get_product_type()` / `$product->get_type()` in `class-woocommerce-gift-cards-lite-public.php`
- Cached the gift-card dashboard widget summary in a `wps_wgm_gift_card_dashboard_summary` transient to avoid the full `WP_Query` + meta walk on every dashboard load
- Gated admin asset enqueues (`wps_wgm_enqueue_styles` / `wps_wgm_enqueue_scripts`) behind new screen-detection helpers so gift-card CSS/JS no longer load on unrelated admin pages; same pattern applied on the frontend via `wps_wgm_should_enqueue_frontend_assets()`
- Replaced the per-call `time()` cache-buster on the import-template stylesheet with the plugin version, and moved the report script to footer
- Guarded `wps_wgm_schedule_midnight_reset()` with a 12h transient so `wp_next_scheduled` is not re-checked on every page load
- Added `wps_wgm_allow_remote_notification_fetch` and `wps_wgm_show_admin_toolbar_report` filters to short-circuit remote notification fetches and the admin toolbar report when not needed
- Consolidated the placeholder `str_replace()` calls in `Woocommerce_Gift_Cards_Common_Function` into a single batched call and removed redundant `apply_filters` repetitions in `wps_wgm_after_add_to_cart_button`
- Added `includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php` and wired its AJAX handler in `Woocommerce_Gift_Cards_Lite::define_admin_hooks()`; localized the AJAX action + nonce for the admin script
- Bumped plugin version to 3.2.7 (header, `WPS_WGC_VERSION`, `Woocommerce_Gift_Cards_Lite::$version` fallback) and tested-up-to headers (WP 6.9.4, WC 10.7.0)

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Gift card admin pages still load CSS/JS; unrelated admin pages (Tools, Users, generic post edit) no longer enqueue gift-card assets
  - Frontend gift-card product page, account page, and `[wps_check_your_gift_card_balance]` shortcode pages still enqueue assets; non-gift-card product/page does not
  - Dashboard widget shows correct issued/redeemed/remaining/expired totals on first load and after the transient is cleared
  - Talk to an Expert form submits successfully with valid nonce; rejects on missing/invalid nonce
  - Repeated calls to `wps_wgm_giftcard_enable()` / `wps_wgm_is_par_active()` within the same request return cached value (verified via xdebug breakpoint)
  - Plugin version reads as 3.2.7 in WP plugin list and `WPS_WGC_VERSION` constant

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
