### PR TITLE
feature/WPS-6756-performance-optimization

### DIFF
--- a/admin/css/woocommerce_gift_cards_lite-admin.css
+++ b/admin/css/woocommerce_gift_cards_lite-admin.css
@@ -4546,6 +4546,21 @@ body.wps-wgm-expert-modal-open {
     gap: 18px;
 }
 
+.wps-wgm-expert-modal__form[hidden] {
+    display: none !important;
+}
+
+.wps-wgm-expert-modal.is-success .wps-wgm-expert-modal__header {
+    display: none;
+}
+
+.wps-wgm-expert-modal.is-success .wps-wgm-expert-modal__panel {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-height: min(520px, calc(100vh - 120px));
+}
+
 .wps-wgm-expert-modal__grid {
     display: grid;
     gap: 16px;

--- a/admin/css/wpswings-onboarding-admin.css
+++ b/admin/css/wpswings-onboarding-admin.css
@@ -1055,3 +1055,174 @@ input[type="text"] {
     max-width: 100% !important;
   }
 }
+
+/* Deactivation feedback modal */
+.wps-deactivation-feedback-wrapper-background {
+  max-width: 750px;
+}
+
+.wps-deactivation-feedback-wrapper {
+  border-radius: 0;
+  padding: 32px 56px 24px;
+}
+
+.wps-deactivation-feedback-wrapper .wps-on-boarding-close-btn {
+  border: 2px solid #0073aa;
+  box-shadow: none;
+  height: 32px;
+  right: 10px;
+  top: 12px;
+  width: 32px;
+}
+
+.wps-deactivation-feedback-wrapper .wps-on-boarding-close-btn a {
+  color: #111827;
+}
+
+.wps-deactivation-feedback-wrapper .wps-on-boarding-close-btn .close-form::before {
+  font-size: 24px;
+  line-height: 28px;
+}
+
+.wps-deactivation-feedback-wrapper .wps-on-boarding-heading {
+  color: #111827;
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.45;
+  margin: 0 auto 12px;
+  max-width: 640px;
+}
+
+.wps-deactivation-feedback-wrapper .wps-on-boarding-desc {
+  color: #6b7280;
+  font-size: 16px;
+  line-height: 1.5;
+  margin: 0 auto 40px;
+  max-width: 520px;
+}
+
+.wps-deactivation-feedback-form {
+  max-width: 100%;
+}
+
+.wps-deactivation-feedback-form .wps-customer-data-form-single-field {
+  border: 0;
+  display: block;
+  margin: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.wps-deactivation-feedback-form .wps-customer-data-form-single-field:first-of-type > .on-boarding-label:empty {
+  display: none;
+}
+
+.wps-deactivation-feedback-form .wps-customer-data-form-single-field:first-of-type {
+  margin: 0 0 18px;
+  max-width: 470px;
+}
+
+.wps-deactivation-feedback-form .wps-deactivating-radio-wrapper {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  margin: 0 0 6px;
+  max-width: none;
+  min-height: 17px;
+  width: 100%;
+}
+
+.wps-deactivation-feedback-form .wps-deactivating-radio-wrapper input[type="radio"] {
+  border: 1px solid #8c8f94;
+  height: 16px;
+  width: 16px;
+}
+
+.wps-deactivation-feedback-form .wps-deactivating-radio-wrapper input[type="radio"]:checked::before {
+  height: 6px;
+  margin: 4px;
+  width: 6px;
+}
+
+.wps-deactivation-feedback-form .on-boarding-field-label {
+  color: #4b5563;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.35;
+}
+
+.wps-deactivation-feedback-form .deactivating-textarea-field,
+.wps-deactivation-feedback-form .deactivating-textarea-field.keep_hidden {
+  display: block;
+  max-width: 452px !important;
+  min-height: 66px;
+  resize: vertical;
+  width: 100% !important;
+}
+
+.wps-deactivation-feedback-form .wps-on-boarding-form-btn__wrapper {
+  align-items: center;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin-top: 30px;
+}
+
+.wps-deactivation-feedback-form .wps-on-boarding-form-submit,
+.wps-deactivation-feedback-form .wps-on-boarding-form-no_thanks {
+  display: flex;
+  float: none;
+  margin: 0;
+  max-width: none !important;
+  width: auto;
+}
+
+.wps-deactivation-feedback-form .wps-on-boarding-submit {
+  background: #1a0a3d !important;
+  border: 1px solid #1a0a3d !important;
+  border-radius: 3px;
+  min-width: 286px;
+  padding: 14px 54px 14px 24px;
+}
+
+.wps-deactivation-feedback-form .wps-on-boarding-form-verify:after {
+  right: 22px;
+  top: 16px;
+}
+
+.wps-deactivation-feedback-form .wps-deactivation-no_thanks {
+  align-items: center;
+  color: #1a0a3d !important;
+  display: inline-flex;
+  font-weight: 700;
+  min-height: 54px;
+  text-decoration: none;
+}
+
+@media only screen and (max-width: 767px) {
+  .wps-deactivation-feedback-wrapper {
+    padding: 54px 22px 24px;
+  }
+
+  .wps-deactivation-feedback-wrapper .wps-on-boarding-heading {
+    font-size: 24px;
+    padding-right: 0;
+  }
+
+  .wps-deactivation-feedback-wrapper .wps-on-boarding-desc {
+    margin-bottom: 26px;
+  }
+
+  .wps-deactivation-feedback-form .wps-on-boarding-form-btn__wrapper {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .wps-deactivation-feedback-form .wps-on-boarding-form-submit,
+  .wps-deactivation-feedback-form .wps-on-boarding-form-no_thanks,
+  .wps-deactivation-feedback-form .wps-on-boarding-submit,
+  .wps-deactivation-feedback-form .wps-deactivation-no_thanks {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/admin/js/woocommerce_gift_cards_lite-admin.js
+++ b/admin/js/woocommerce_gift_cards_lite-admin.js
@@ -610,6 +610,8 @@
 			var $successMessage = $modal.find( successMessageSelector ).first();
 			var $submitButton = $form.find( 'button[type="submit"]' ).first();
 
+			$modal.removeClass( 'is-success' );
+
 			if ( $form.length ) {
 				if ( $form.get( 0 ) && 'function' === typeof $form.get( 0 ).reset ) {
 					$form.get( 0 ).reset();
@@ -639,11 +641,13 @@
 			var $form = $modal.find( formSelector ).first();
 			var $success = $modal.find( successSelector ).first();
 			var $successMessage = $modal.find( successMessageSelector ).first();
+			var $dialog = $modal.find( '.wps-wgm-expert-modal__dialog' ).first();
 
 			if ( $form.length ) {
 				$form.attr( 'hidden', true );
 			}
 
+			$modal.addClass( 'is-success' );
 			wpsWgmSetExpertStatus( $modal, '', '' );
 
 			if ( $successMessage.length ) {
@@ -656,6 +660,10 @@
 				window.setTimeout( function() {
 					$success.addClass( 'is-visible' );
 				}, 20 );
+			}
+
+			if ( $dialog.length ) {
+				$dialog.scrollTop( 0 );
 			}
 		}
 
@@ -751,10 +759,6 @@
 
 				if ( isSuccess && message ) {
 					wpsWgmShowExpertSuccessState( $modal, message );
-
-					successCloseTimer = window.setTimeout( function() {
-						wpsWgmToggleExpertModal( false );
-					}, 3000 );
 					return;
 				}
 

--- a/admin/js/wpswings-onboarding-admin.js
+++ b/admin/js/wpswings-onboarding-admin.js
@@ -7,10 +7,12 @@ jQuery(document).ready( function($) {
 
 	var deactivate_url = '';
 
-	// Add Select2.
-	jQuery( '.on-boarding-select2' ).select2({
-		placeholder : 'Select All Suitable Options...',
-	});
+	// Add Select2 when the library is available on the current admin screen.
+	if ( jQuery.fn.select2 ) {
+		jQuery( '.on-boarding-select2' ).select2({
+			placeholder : 'Select All Suitable Options...',
+		});
+	}
 
 	// Add Deactivation id to all deactivation links.
 	embed_id_to_deactivation_urls();
@@ -47,6 +49,7 @@ jQuery(document).ready( function($) {
 
 	/* Skip and deactivate. */
 	jQuery( document ).on( 'click','.wps-deactivation-no_thanks',function(e){
+		e.preventDefault();
 
 		window.location.replace( deactivate_url );
 		wps_hide_onboard_popup();
@@ -117,29 +120,41 @@ jQuery(document).ready( function($) {
 
 	/* Apply deactivate in all the WPS plugins. */
 	function add_deactivate_slugs_callback( all_slugs ) {
-		
-		for ( var i = all_slugs.length - 1; i >= 0; i-- ) {
+		all_slugs = jQuery.isArray( all_slugs ) ? all_slugs : [];
 
-			jQuery( document ).on( 'click', '#deactivate-' + all_slugs[i] ,function(e){
+		jQuery( document ).on( 'click', 'a[href*="action=deactivate"]', function(e) {
+			var slug = jQuery( this ).closest( 'tr' ).attr( 'data-slug' );
+			var href = jQuery( this ).attr( 'href' ) || '';
+			var is_supported_slug = -1 < jQuery.inArray( slug, all_slugs );
+			var is_giftcard_deactivation = -1 < href.indexOf( 'woo-gift-cards-lite%2Fwoocommerce_gift_cards_lite.php' ) || -1 < href.indexOf( 'woo-gift-cards-lite/woocommerce_gift_cards_lite.php' );
 
-				e.preventDefault();
-				deactivate_url = jQuery( this ).attr( 'href' );
-				plugin_name = jQuery( this ).attr( 'aria-label' );
-				jQuery( '#plugin-name' ).val( plugin_name.replace( 'Deactivate ', '' ) );
-				plugin_name = plugin_name.replace( 'Deactivate ', '' );
-				jQuery( '#plugin-name' ).val( plugin_name );
-				jQuery( '.wps-on-boarding-heading' ).text( plugin_name + ' Feedback' );
-				var placeholder = jQuery( '#deactivation-reason-text' ).attr( 'placeholder' );
-				jQuery( '#deactivation-reason-text' ).attr( 'placeholder', placeholder.replace( '{plugin-name}', plugin_name ) );
-				wps_show_onboard_popup();
-			});
-		}
+			if ( ! is_supported_slug && ! is_giftcard_deactivation ) {
+				return;
+			}
+
+			e.preventDefault();
+			deactivate_url = href;
+			var plugin_name = jQuery( this ).attr( 'aria-label' ) || '';
+			plugin_name = plugin_name.replace( 'Deactivate ', '' );
+
+			if ( ! plugin_name ) {
+				plugin_name = jQuery( this ).closest( 'tr' ).find( '.plugin-title strong' ).first().text();
+			}
+
+			jQuery( '#plugin-name' ).val( plugin_name );
+			jQuery( '.wps-on-boarding-heading' ).text( plugin_name + ' Feedback' );
+
+			var placeholder = jQuery( '#deactivation-reason-text' ).attr( 'placeholder' ) || '';
+			jQuery( '#deactivation-reason-text' ).attr( 'placeholder', placeholder.replace( '{plugin-name}', plugin_name ) );
+			wps_show_onboard_popup();
+		});
 	}
 
 	/* Add deactivate id in all the plugins links. */
 	function embed_id_to_deactivation_urls() {
 		jQuery( 'a' ).each(function(){
-		    if ( 'Deactivate' == jQuery(this).text() && 0 < jQuery(this).attr( 'href' ).search( 'action=deactivate' ) ) {
+			var href = jQuery(this).attr( 'href' ) || '';
+		    if ( 'Deactivate' == jQuery.trim( jQuery(this).text() ) && 0 < href.search( 'action=deactivate' ) ) {
 		    	if( 'undefined' == typeof jQuery(this).attr( 'id' ) ) {
 			    	var slug = jQuery(this).closest( 'tr' ).attr( 'data-slug' );
 			    	jQuery(this).attr( 'id', 'deactivate-' + slug );

--- a/includes/extra-templates/wpswings-deactivation-template-display.php
+++ b/includes/extra-templates/wpswings-deactivation-template-display.php
@@ -24,8 +24,8 @@ if ( ! empty( $form_fields ) ) : ?>
 		<img src="<?php echo esc_url( WPS_WGC_URL . 'assets/images/loading.gif' ); ?>">
 	</div>
 	<div class="wps-onboarding-section">
-		<div class="wps-on-boarding-wrapper-background">
-		<div class="wps-on-boarding-wrapper">
+		<div class="wps-on-boarding-wrapper-background wps-deactivation-feedback-wrapper-background">
+		<div class="wps-on-boarding-wrapper wps-deactivation-feedback-wrapper">
 			<div class="wps-on-boarding-close-btn">
 				<a href="javascript:void(0);">
 					<span class="close-form">x</span>
@@ -33,7 +33,7 @@ if ( ! empty( $form_fields ) ) : ?>
 			</div>
 			<h3 class="wps-on-boarding-heading"></h3>
 			<p class="wps-on-boarding-desc"><?php esc_html_e( 'May we have a little info about why you are deactivating?', 'woo-gift-cards-lite' ); ?></p>
-			<form action="#" method="post" class="wps-on-boarding-form">
+			<form action="#" method="post" class="wps-on-boarding-form wps-deactivation-feedback-form">
 				<?php foreach ( $form_fields as $key => $field_attr ) : ?>
 					<?php $this->render_field_html( $field_attr, 'deactivating' ); ?>
 				<?php endforeach; ?>


### PR DESCRIPTION
## Task Link
WPS-6756

## Summary
Performance optimization pass across the plugin plus a new admin "Talk to an Expert" form. Reduced repeated `get_option()` and `wp_get_object_terms()` calls on hot paths, gated admin and frontend asset enqueues to gift-card-relevant screens, cached the dashboard widget summary in a transient, and bumped the plugin version to 3.2.7.

## Changes Made
- Added per-request option cache helper `wps_wgm_get_plugin_option()` and replaced repeated `get_option()` calls in common-function and public classes with it
- Memoized `wps_wgm_is_par_active()`, `wps_wgm_is_par_enable()`, and `wps_wgm_giftcard_enable()` with static flags so subsequent calls in the same request return immediately
- Replaced `wp_get_object_terms( $id, 'product_type' )` lookups with `WC_Product_Factory::get_product_type()` / `$product->get_type()` in `class-woocommerce-gift-cards-lite-public.php`
- Cached the gift-card dashboard widget summary in a `wps_wgm_gift_card_dashboard_summary` transient to avoid the full `WP_Query` + meta walk on every dashboard load
- Gated admin asset enqueues (`wps_wgm_enqueue_styles` / `wps_wgm_enqueue_scripts`) behind new screen-detection helpers so gift-card CSS/JS no longer load on unrelated admin pages; same pattern applied on the frontend via `wps_wgm_should_enqueue_frontend_assets()`
- Replaced the per-call `time()` cache-buster on the import-template stylesheet with the plugin version, and moved the report script to footer
- Guarded `wps_wgm_schedule_midnight_reset()` with a 12h transient so `wp_next_scheduled` is not re-checked on every page load
- Added `wps_wgm_allow_remote_notification_fetch` and `wps_wgm_show_admin_toolbar_report` filters to short-circuit remote notification fetches and the admin toolbar report when not needed
- Consolidated the placeholder `str_replace()` calls in `Woocommerce_Gift_Cards_Common_Function` into a single batched call and removed redundant `apply_filters` repetitions in `wps_wgm_after_add_to_cart_button`
- Added `includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php` and wired its AJAX handler in `Woocommerce_Gift_Cards_Lite::define_admin_hooks()`; localized the AJAX action + nonce for the admin script
- Bumped plugin version to 3.2.7 (header, `WPS_WGC_VERSION`, `Woocommerce_Gift_Cards_Lite::$version` fallback) and tested-up-to headers (WP 6.9.4, WC 10.7.0)

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Gift card admin pages still load CSS/JS; unrelated admin pages (Tools, Users, generic post edit) no longer enqueue gift-card assets
  - Frontend gift-card product page, account page, and `[wps_check_your_gift_card_balance]` shortcode pages still enqueue assets; non-gift-card product/page does not
  - Dashboard widget shows correct issued/redeemed/remaining/expired totals on first load and after the transient is cleared
  - Talk to an Expert form submits successfully with valid nonce; rejects on missing/invalid nonce
  - Repeated calls to `wps_wgm_giftcard_enable()` / `wps_wgm_is_par_active()` within the same request return cached value (verified via xdebug breakpoint)
  - Plugin version reads as 3.2.7 in WP plugin list and `WPS_WGC_VERSION` constant

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
