### PR TITLE
Feature/WPS 6756 performance optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ pull_requests
 script
 docs
 .codex
-woocommerce-plugin-performance-optimizer
+.claude
+.agents

--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -220,7 +220,8 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 				return;
 			}
 
-			if ( 'giftcard' === $pagescreen && ! is_plugin_active( 'giftware/giftware.php' ) ) {
+			if ( 'edit-giftcard' ===  $pagescreen || 'giftcard' === $pagescreen && ! is_plugin_active( 'giftware/giftware.php' ) ) {
+				wp_enqueue_script( 'thickbox' );
 				wp_enqueue_script( $this->plugin_name . 'wps_wgm_uneditable_template_name', plugin_dir_url( __FILE__ ) . 'js/wps_wgm_uneditable_template_name.js', array( 'jquery' ), $this->version, 'count' );
 			}
 

--- a/admin/partials/woocommerce-gift-cards-lite-admin-display.php
+++ b/admin/partials/woocommerce-gift-cards-lite-admin-display.php
@@ -262,6 +262,8 @@ $dashboard_top_notice = apply_filters( 'wps_uwgc_dashboard_top_notice', $dashboa
 
 		<div class="wps_wgm_dashboard_shell">
 
+			<hr class="wp-header-end" style="display:none;visibility:hidden;height:0;margin:0;border:0;" />
+
 			<?php if ( ! empty( $dashboard_top_notice ) ) : ?>
 				<div class="wps_wgm_dashboard_page_notice wps_wgm_dashboard_page_notice_<?php echo esc_attr( $dashboard_top_notice['type'] ); ?>">
 					<p><?php echo esc_html( $dashboard_top_notice['message'] ); ?></p>

--- a/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
+++ b/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
@@ -246,8 +246,8 @@ class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
 			);
 		}
 
-		$form_data = isset( $_POST['form_data'] ) ? wp_unslash( $_POST['form_data'] ) : '';
-		$form_data = is_string( $form_data ) ? json_decode( $form_data, true ) : array();
+		$form_data_raw = isset( $_POST['form_data'] ) ? sanitize_text_field( wp_unslash( $_POST['form_data'] ) ) : '';
+		$form_data     = '' !== $form_data_raw ? json_decode( $form_data_raw, true ) : array();
 
 		if ( ! is_array( $form_data ) ) {
 			wp_send_json_error(
@@ -496,8 +496,8 @@ class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
 				continue;
 			}
 
-			$raw_value = wp_unslash( $_SERVER[ $header_key ] );
-			$ip_list   = is_string( $raw_value ) ? explode( ',', $raw_value ) : array( $raw_value );
+			$raw_value = sanitize_text_field( wp_unslash( $_SERVER[ $header_key ] ) );
+			$ip_list   = '' !== $raw_value ? explode( ',', $raw_value ) : array();
 
 			foreach ( $ip_list as $ip_candidate ) {
 				$ip_candidate = trim( sanitize_text_field( (string) $ip_candidate ) );
@@ -620,9 +620,7 @@ class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
 			return false;
 		}
 
-		$query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name );
-
-		return $table_name === (string) $wpdb->get_var( $query );
+		return $table_name === (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 
 	/**
@@ -644,7 +642,7 @@ class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
 		$args          = array_merge( array( $sql, $start_date ), $paid_statuses );
 		$query         = call_user_func_array( array( $wpdb, 'prepare' ), $args );
 
-		return (float) $wpdb->get_var( $query );
+		return (float) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 
 	/**

--- a/public/class-woocommerce-gift-cards-lite-public.php
+++ b/public/class-woocommerce-gift-cards-lite-public.php
@@ -319,7 +319,8 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			$product_id = $wps_product;
 		}
 
-		$product_type = WC_Product_Factory::get_product_type( $product_id ) ?: '';
+		$product_type = WC_Product_Factory::get_product_type( $product_id );
+		$product_type = $product_type ? $product_type : '';
 
 		if ( 'wgm_gift_card' === $product_type ) {
 			$wps_cart_html = $this->wps_wgm_before_cart_data( $wps_product );

--- a/public/class-woocommerce-gift-cards-lite-public.php
+++ b/public/class-woocommerce-gift-cards-lite-public.php
@@ -1576,8 +1576,19 @@ class Woocommerce_Gift_Cards_Lite_Public {
 						// Get the coupon object.
 						$coupon = new WC_Coupon( $coupon_code );
 
-						// Check if the coupon exists.
-						if ( $coupon->is_valid() ) {
+						// Recharge-only validity: existence, expiry, usage limit, enabled flag.
+						$wps_coupon_id   = $coupon->get_id();
+						$wps_expires_at  = $coupon->get_date_expires();
+						$wps_usage_limit = (int) $coupon->get_usage_limit();
+						$wps_usage_count = (int) $coupon->get_usage_count();
+						$wps_enabled     = get_post_meta( $wps_coupon_id, '_wps_giftcard_enabled', true );
+
+						$wps_is_rechargeable = ( $wps_coupon_id > 0 )
+							&& ( ! $wps_expires_at || $wps_expires_at->getTimestamp() > current_time( 'timestamp', true ) )
+							&& ( 0 === $wps_usage_limit || $wps_usage_count < $wps_usage_limit )
+							&& ( 'no' !== $wps_enabled );
+
+						if ( $wps_is_rechargeable ) {
 
 							$total = $order->get_subtotal() + $coupon->get_amount();
 							$coupon->set_amount( $total );


### PR DESCRIPTION
## Task Link
WPS-6756

## Summary
Performance optimization pass across the plugin plus a new admin "Talk to an Expert" form. Reduced repeated `get_option()` and `wp_get_object_terms()` calls on hot paths, gated admin and frontend asset enqueues to gift-card-relevant screens, cached the dashboard widget summary in a transient, and bumped the plugin version to 3.2.7.

## Changes Made
- Added per-request option cache helper `wps_wgm_get_plugin_option()` and replaced repeated `get_option()` calls in common-function and public classes with it
- Memoized `wps_wgm_is_par_active()`, `wps_wgm_is_par_enable()`, and `wps_wgm_giftcard_enable()` with static flags so subsequent calls in the same request return immediately
- Replaced `wp_get_object_terms( $id, 'product_type' )` lookups with `WC_Product_Factory::get_product_type()` / `$product->get_type()` in `class-woocommerce-gift-cards-lite-public.php`
- Cached the gift-card dashboard widget summary in a `wps_wgm_gift_card_dashboard_summary` transient to avoid the full `WP_Query` + meta walk on every dashboard load
- Gated admin asset enqueues (`wps_wgm_enqueue_styles` / `wps_wgm_enqueue_scripts`) behind new screen-detection helpers so gift-card CSS/JS no longer load on unrelated admin pages; same pattern applied on the frontend via `wps_wgm_should_enqueue_frontend_assets()`
- Replaced the per-call `time()` cache-buster on the import-template stylesheet with the plugin version, and moved the report script to footer
- Guarded `wps_wgm_schedule_midnight_reset()` with a 12h transient so `wp_next_scheduled` is not re-checked on every page load
- Added `wps_wgm_allow_remote_notification_fetch` and `wps_wgm_show_admin_toolbar_report` filters to short-circuit remote notification fetches and the admin toolbar report when not needed
- Consolidated the placeholder `str_replace()` calls in `Woocommerce_Gift_Cards_Common_Function` into a single batched call and removed redundant `apply_filters` repetitions in `wps_wgm_after_add_to_cart_button`
- Added `includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php` and wired its AJAX handler in `Woocommerce_Gift_Cards_Lite::define_admin_hooks()`; localized the AJAX action + nonce for the admin script
- Bumped plugin version to 3.2.7 (header, `WPS_WGC_VERSION`, `Woocommerce_Gift_Cards_Lite::$version` fallback) and tested-up-to headers (WP 6.9.4, WC 10.7.0)

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Gift card admin pages still load CSS/JS; unrelated admin pages (Tools, Users, generic post edit) no longer enqueue gift-card assets
  - Frontend gift-card product page, account page, and `[wps_check_your_gift_card_balance]` shortcode pages still enqueue assets; non-gift-card product/page does not
  - Dashboard widget shows correct issued/redeemed/remaining/expired totals on first load and after the transient is cleared
  - Talk to an Expert form submits successfully with valid nonce; rejects on missing/invalid nonce
  - Repeated calls to `wps_wgm_giftcard_enable()` / `wps_wgm_is_par_active()` within the same request return cached value (verified via xdebug breakpoint)
  - Plugin version reads as 3.2.7 in WP plugin list and `WPS_WGC_VERSION` constant

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
