### PR TITLE
Feature/WPS 6756 performance optimization

### DIFF
--- a/admin/class-woocommerce-gift-cards-lite-admin.php
+++ b/admin/class-woocommerce-gift-cards-lite-admin.php
@@ -220,7 +220,7 @@ class Woocommerce_Gift_Cards_Lite_Admin {
 				return;
 			}
 
-			if ( 'edit-giftcard' ===  $pagescreen || 'giftcard' === $pagescreen && ! is_plugin_active( 'giftware/giftware.php' ) ) {
+			if ( 'edit-giftcard' === $pagescreen || ( 'giftcard' === $pagescreen && ! is_plugin_active( 'giftware/giftware.php' ) ) ) {
 				wp_enqueue_script( 'thickbox' );
 				wp_enqueue_script( $this->plugin_name . 'wps_wgm_uneditable_template_name', plugin_dir_url( __FILE__ ) . 'js/wps_wgm_uneditable_template_name.js', array( 'jquery' ), $this->version, 'count' );
 			}

--- a/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
+++ b/includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php
@@ -638,11 +638,14 @@ class Woocommerce_Gift_Cards_Lite_Talk_To_Expert_Form {
 		$paid_statuses = self::wps_wgm_get_paid_status_values();
 		$placeholders  = implode( ', ', array_fill( 0, count( $paid_statuses ), '%s' ) );
 		$start_date    = gmdate( 'Y-m-d H:i:s', strtotime( '-12 months' ) );
-		$sql           = "SELECT COALESCE(SUM(total_sales), 0) FROM {$table_name} WHERE parent_id = 0 AND date_paid IS NOT NULL AND date_paid >= %s AND status IN ({$placeholders})";
-		$args          = array_merge( array( $sql, $start_date ), $paid_statuses );
-		$query         = call_user_func_array( array( $wpdb, 'prepare' ), $args );
+		$args          = array_merge( array( $start_date ), $paid_statuses );
 
-		return (float) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (float) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT COALESCE(SUM(total_sales), 0) FROM {$table_name} WHERE parent_id = 0 AND date_paid IS NOT NULL AND date_paid >= %s AND status IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$args
+			)
+		);
 	}
 
 	/**

--- a/public/class-woocommerce-gift-cards-lite-public.php
+++ b/public/class-woocommerce-gift-cards-lite-public.php
@@ -118,7 +118,18 @@ class Woocommerce_Gift_Cards_Lite_Public {
 			$page_content = ! empty( $page->post_content ) ? $page->post_content : '';
 		}
 
-		if ( str_contains( $page_content, 'wps_check_your_gift_card_balance' ) || ( function_exists( 'is_account_page' ) && is_account_page() ) ) {
+		// Auto-generated "Gift Card" page is a WP page that embeds the gift card
+		// product category via [product_category category='wps_wgm_giftcard'].
+		$is_giftcard_category_page = str_contains( $page_content, '[product_category' )
+			&& str_contains( $page_content, 'wps_wgm_giftcard' );
+
+		if ( str_contains( $page_content, 'wps_check_your_gift_card_balance' )
+			|| ( function_exists( 'is_account_page' ) && is_account_page() )
+			|| ( function_exists( 'is_shop' ) && is_shop() )
+			|| ( function_exists( 'is_product_taxonomy' ) && is_product_taxonomy() )
+			|| ( function_exists( 'is_cart' ) && is_cart() )
+			|| ( function_exists( 'is_checkout' ) && is_checkout() )
+			|| $is_giftcard_category_page ) {
 			return true;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpswings
 Donate link:  https://wpswings.com/
 Tags: gift, gift card, gift certificates, woocommerce gift cards, gift vouchers
 Requires at least: 6.7
-Tested up to: 6.9.4
+Tested up to: 7.0
 WC requires at least: 6.5
 WC tested up to: 10.7.0
 Stable tag:  3.2.7

--- a/woocommerce_gift_cards_lite.php
+++ b/woocommerce_gift_cards_lite.php
@@ -22,7 +22,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.txt
  * Text Domain:       woo-gift-cards-lite
  * Requires Plugins:  woocommerce
- * Tested up to:      6.9.4
+ * Tested up to:      7.0
  * Requires at least: 6.7
  * WC tested up to:   10.7.0
  * WC requires at least: 6.5


### PR DESCRIPTION
## Task Link
WPS-6756

## Summary
Performance optimization pass across the plugin plus a new admin "Talk to an Expert" form. Reduced repeated `get_option()` and `wp_get_object_terms()` calls on hot paths, gated admin and frontend asset enqueues to gift-card-relevant screens, cached the dashboard widget summary in a transient, and bumped the plugin version to 3.2.7.

## Changes Made
- Added per-request option cache helper `wps_wgm_get_plugin_option()` and replaced repeated `get_option()` calls in common-function and public classes with it
- Memoized `wps_wgm_is_par_active()`, `wps_wgm_is_par_enable()`, and `wps_wgm_giftcard_enable()` with static flags so subsequent calls in the same request return immediately
- Replaced `wp_get_object_terms( $id, 'product_type' )` lookups with `WC_Product_Factory::get_product_type()` / `$product->get_type()` in `class-woocommerce-gift-cards-lite-public.php`
- Cached the gift-card dashboard widget summary in a `wps_wgm_gift_card_dashboard_summary` transient to avoid the full `WP_Query` + meta walk on every dashboard load
- Gated admin asset enqueues (`wps_wgm_enqueue_styles` / `wps_wgm_enqueue_scripts`) behind new screen-detection helpers so gift-card CSS/JS no longer load on unrelated admin pages; same pattern applied on the frontend via `wps_wgm_should_enqueue_frontend_assets()`
- Replaced the per-call `time()` cache-buster on the import-template stylesheet with the plugin version, and moved the report script to footer
- Guarded `wps_wgm_schedule_midnight_reset()` with a 12h transient so `wp_next_scheduled` is not re-checked on every page load
- Added `wps_wgm_allow_remote_notification_fetch` and `wps_wgm_show_admin_toolbar_report` filters to short-circuit remote notification fetches and the admin toolbar report when not needed
- Consolidated the placeholder `str_replace()` calls in `Woocommerce_Gift_Cards_Common_Function` into a single batched call and removed redundant `apply_filters` repetitions in `wps_wgm_after_add_to_cart_button`
- Added `includes/class-woocommerce-gift-cards-lite-talk-to-expert-form.php` and wired its AJAX handler in `Woocommerce_Gift_Cards_Lite::define_admin_hooks()`; localized the AJAX action + nonce for the admin script
- Bumped plugin version to 3.2.7 (header, `WPS_WGC_VERSION`, `Woocommerce_Gift_Cards_Lite::$version` fallback) and tested-up-to headers (WP 6.9.4, WC 10.7.0)

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Gift card admin pages still load CSS/JS; unrelated admin pages (Tools, Users, generic post edit) no longer enqueue gift-card assets
  - Frontend gift-card product page, account page, and `[wps_check_your_gift_card_balance]` shortcode pages still enqueue assets; non-gift-card product/page does not
  - Dashboard widget shows correct issued/redeemed/remaining/expired totals on first load and after the transient is cleared
  - Talk to an Expert form submits successfully with valid nonce; rejects on missing/invalid nonce
  - Repeated calls to `wps_wgm_giftcard_enable()` / `wps_wgm_is_par_active()` within the same request return cached value (verified via xdebug breakpoint)
  - Plugin version reads as 3.2.7 in WP plugin list and `WPS_WGC_VERSION` constant

## Screenshots / Demo (if applicable)

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
